### PR TITLE
fix compilation with msvc6 and msvc2005

### DIFF
--- a/prboom2/VisualC6/Doom.dsp
+++ b/prboom2/VisualC6/Doom.dsp
@@ -410,6 +410,10 @@ SOURCE=..\src\f_finale.h
 # End Source File
 # Begin Source File
 
+SOURCE=..\src\f_finale2.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\src\f_wipe.c
 
 !IF  "$(CFG)" == "Doom - Win32 Release"
@@ -965,6 +969,14 @@ SOURCE=..\src\tables.c
 # Begin Source File
 
 SOURCE=..\src\tables.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\src\umapinfo.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\src\umapinfo.h
 # End Source File
 # Begin Source File
 

--- a/prboom2/VisualC8/Doom.vcproj
+++ b/prboom2/VisualC8/Doom.vcproj
@@ -1548,6 +1548,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\src\f_finale2.c"
+				>
+			</File>
+			<File
 				RelativePath="..\src\f_wipe.c"
 				>
 				<FileConfiguration
@@ -5793,6 +5797,14 @@
 			</File>
 			<File
 				RelativePath="..\src\tables.h"
+				>
+			</File>
+			<File
+				RelativePath="..\src\umapinfo.c"
+				>
+			</File>
+			<File
+				RelativePath="..\src\umapinfo.h"
 				>
 			</File>
 			<File

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -226,13 +226,14 @@ float Get_TextSpeed(void)
 
 void F_Ticker(void)
 {
+  int i;
+
 	if (using_FMI)
 	{
 		FMI_Ticker();
 		return;
 	}
 	
-  int i;
   if (!demo_compatibility)
     WI_checkForAccelerate();  // killough 3/28/98: check for acceleration
   else

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1581,12 +1581,12 @@ void G_DoCompleted (void)
   wminfo.nextmapinfo = NULL;
   if (gamemapinfo)
   {
+	  const char *next = "";
 	  if (gamemapinfo->endpic[0] && gamemapinfo->nointermission)
 	  {
 		  gameaction = ga_victory;
 		  return;
 	  }
-	  const char *next = "";
 	  if (secretexit) next = gamemapinfo->nextsecret;
 	  if (next[0] == 0) next = gamemapinfo->nextmap;
 	  if (next[0])

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -574,11 +574,11 @@ void M_AddEpisode(const char *map, char *def)
 	}
 	else
 	{
+		int epi, mapnum;
 		const char *gfx = strtok(def, "\n");
 		const char *txt = strtok(NULL, "\n");
 		const char *alpha = strtok(NULL, "\n");
 		if (EpiDef.numitems >= 8) return;
-		int epi, mapnum;
 		G_ValidateMapName(map, &epi, &mapnum);
 		EpiMenuEpi[EpiDef.numitems] = epi;
 		EpiMenuMap[EpiDef.numitems] = mapnum;


### PR DESCRIPTION
C89 standard requires (?) that all variables be declared before any code