### PR TITLE
INI Format

### DIFF
--- a/prboom2/configure.ac
+++ b/prboom2/configure.ac
@@ -221,6 +221,12 @@ AS_IF([test "x$with_image" != xno],
 
 AC_EGREP_HEADER(sockaddr_in6,netinet/in.h,AC_DEFINE(HAVE_IPv6,1,[Define if you have struct sockaddr_in6]))
 
+dnl --- [CG] INI configuration
+AC_DEFINE(INI_USE_STACK,0,[Define to allocate INI lines on the stack])
+AC_DEFINE(INI_STOP_ON_FIRST_ERROR,1,[Define to stop INI parsing on the 1st error])
+AC_DEFINE(INI_MAX_LINE,1048576,[Maximum line length (1 MB, give or take)])
+AC_DEFINE(INI_HANDLER_LINENO,1,[Pass line number to INI key/value handler (required)])
+
 dnl --- Options
 dnl - Always use highres mode and basic checks - anyone that wants these off can edit the config.h
 AC_DEFINE(HIGHRES,1,[Define for high resolution support])

--- a/prboom2/src/Makefile.am
+++ b/prboom2/src/Makefile.am
@@ -59,7 +59,8 @@ COMMON_SRC = \
  i_pcsound.c    i_pcsound.h \
  g_overflow.c   g_overflow.h       hu_tracers.c     hu_tracers.h \
  s_advsound.c   s_advsound.h       i_capture.c      i_capture.h \
- sc_man.c       sc_man.h
+ sc_man.c       sc_man.h		   umapinfo.c       f_finale2.c \
+ ini.c
 
 NET_CLIENT_SRC = d_client.c
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1837,7 +1837,7 @@ static void D_DoomMainSetup(void)
 	  for (p = -1; (p = W_ListNumFromName("UMAPINFO", p)) >= 0; )
 	  {
 		  const unsigned char * lump = (const unsigned char *)W_CacheLumpNum(p);
-		  ParseUMapInfo(lump, W_LumpLength(p), I_Error);
+		  UMI_Parse(lump, W_LumpLength(p));
 	  }
   }
 

--- a/prboom2/src/d_player.h
+++ b/prboom2/src/d_player.h
@@ -56,6 +56,7 @@
 #pragma interface
 #endif
 
+struct UMIMapEntryStruct;
 
 //
 // Player states.
@@ -221,7 +222,7 @@ typedef struct
 typedef struct
 {
   int         epsd;   // episode # (0-2)
-  struct MapEntry *lastmapinfo;
+  struct UMIMapEntryStruct *lastmapinfo;
 
   // if true, splash the secret level
   dboolean   didsecret;
@@ -229,8 +230,8 @@ typedef struct
   // previous and next levels, origin 0
   int         last;
   int         next;
-  int         nextep;	// for when MAPINFO progression crosses into another episode.
-  struct MapEntry *nextmapinfo;
+  int         nextep;  // for when MAPINFO progression crosses into another episode.
+  struct UMIMapEntryStruct *nextmapinfo;
 
   int         maxkills;
   int         maxitems;

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -153,9 +153,9 @@ extern  dboolean   autostart;
 
 // Selected by user.
 extern  skill_t         gameskill;
-extern  int   gameepisode;
-extern  int   gamemap;
-struct MapEntry *gamemapinfo;
+extern  int  gameepisode;
+extern  int  gamemap;
+UMIMapEntry *gamemapinfo;
 
 // Nightmare mode flag, single player.
 extern  dboolean         respawnmonsters;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -89,7 +89,7 @@
 #define SAVEGAMESIZE  0x20000
 #define SAVESTRINGSIZE  24
 
-struct MapEntry *G_LookupMapinfo(int gameepisode, int gamemap);
+UMIMapEntry* G_LookupMapinfo(int gameepisode, int gamemap);
 
 // e6y
 // It is signature for new savegame format with continuous numbering.
@@ -111,11 +111,11 @@ static short    consistancy[MAXPLAYERS][BACKUPTICS];
 gameaction_t    gameaction;
 gamestate_t     gamestate;
 skill_t         gameskill;
-dboolean         respawnmonsters;
+dboolean        respawnmonsters;
 int             gameepisode;
 int             gamemap;
-struct MapEntry		*gamemapinfo;
-dboolean         paused;
+UMIMapEntry    *gamemapinfo;
+dboolean        paused;
 // CPhipps - moved *_loadgame vars here
 static dboolean forced_loadgame = false;
 static dboolean command_loadgame = false;
@@ -2662,33 +2662,21 @@ void G_SetFastParms(int fast_pending)
   }
 }
 
-struct MapEntry *G_LookupMapinfo(int gameepisode, int gamemap)
-{
+UMIMapEntry* G_LookupMapinfo(int gameepisode, int gamemap) {
 	char lumpname[9];
-	unsigned i;
-	if (gamemode == commercial) snprintf(lumpname, 9, "MAP%02d", gamemap);
-	else snprintf(lumpname, 9, "E%dM%d", gameepisode, gamemap);
-	for (i = 0; i < Maps.mapcount; i++)
-	{
-		if (!stricmp(lumpname, Maps.maps[i].mapname))
-		{
-			return &Maps.maps[i];
-		}
-	}
-	return NULL;
+
+	if (gamemode == commercial) {
+        snprintf(lumpname, 9, "MAP%02d", gamemap);
+    }
+	else {
+        snprintf(lumpname, 9, "E%dM%d", gameepisode, gamemap);
+    }
+
+    return UMI_LookupMapInfo(lumpname);
 }
 
-struct MapEntry *G_LookupMapinfoByName(const char *lumpname)
-{
-	unsigned i;
-	for (i = 0; i < Maps.mapcount; i++)
-	{
-		if (!stricmp(lumpname, Maps.maps[i].mapname))
-		{
-			return &Maps.maps[i];
-		}
-	}
-	return NULL;
+UMIMapEntry* G_LookupMapinfoByName(const char *lumpname) {
+    return UMI_LookupMapInfo(lumpname);
 }
 
 int G_ValidateMapName(const char *mapname, int *pEpi, int *pMap)

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -734,47 +734,47 @@ void HU_Start(void)
 
   if (gamemapinfo != NULL)
   {
-	  s = gamemapinfo->mapname;
-	  while (*s)
-		  HUlib_addCharToTextLine(&w_title, *(s++));
+      s = gamemapinfo->mapname;
+      while (*s)
+          HUlib_addCharToTextLine(&w_title, *(s++));
 
-	  HUlib_addCharToTextLine(&w_title, ':');
-	  HUlib_addCharToTextLine(&w_title, ' ');
-	  s = gamemapinfo->levelname;
-	  if (!s) s = "Unnamed";
-	  while (*s)
-		  HUlib_addCharToTextLine(&w_title, *(s++));
+      HUlib_addCharToTextLine(&w_title, ':');
+      HUlib_addCharToTextLine(&w_title, ' ');
+      s = gamemapinfo->levelname;
+      if (!s) s = "Unnamed";
+      while (*s)
+          HUlib_addCharToTextLine(&w_title, *(s++));
 
   }
   else
   {
-	  // initialize the automap's level title widget
-	  // e6y: stop SEGV here when gamemap is not initialized
-	  if (gamestate == GS_LEVEL && gamemap > 0) /* cph - stop SEGV here when not in level */
-		  switch (gamemode)
-		  {
-		  case shareware:
-		  case registered:
-		  case retail:
-			  s = HU_TITLE;
-			  break;
+      // initialize the automap's level title widget
+      // e6y: stop SEGV here when gamemap is not initialized
+      if (gamestate == GS_LEVEL && gamemap > 0) /* cph - stop SEGV here when not in level */
+          switch (gamemode)
+          {
+          case shareware:
+          case registered:
+          case retail:
+              s = HU_TITLE;
+              break;
 
-		  case commercial:
-		  default:  // Ty 08/27/98 - modified to check mission for TNT/Plutonia
-			  s = (gamemission == pack_tnt) ? HU_TITLET :
-				  (gamemission == pack_plut) ? HU_TITLEP : HU_TITLE2;
-			  break;
-		  }
-	  else s = "";
+          case commercial:
+          default:  // Ty 08/27/98 - modified to check mission for TNT/Plutonia
+              s = (gamemission == pack_tnt) ? HU_TITLET :
+                  (gamemission == pack_plut) ? HU_TITLEP : HU_TITLE2;
+              break;
+          }
+      else s = "";
 
-	  // Chex.exe always uses the episode 1 level title
-	  // eg. E2M1 gives the title for E1M1
-	  if (gamemission == chex)
-	  {
-		  s = HU_TITLEC;
-	  }
-	  while (*s)
-		  HUlib_addCharToTextLine(&w_title, *(s++));
+      // Chex.exe always uses the episode 1 level title
+      // eg. E2M1 gives the title for E1M1
+      if (gamemission == chex)
+      {
+          s = HU_TITLEC;
+      }
+      while (*s)
+          HUlib_addCharToTextLine(&w_title, *(s++));
   }
 
 

--- a/prboom2/src/ini.c
+++ b/prboom2/src/ini.c
@@ -1,0 +1,201 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "ini.h"
+
+#if !INI_USE_STACK
+#include <stdlib.h>
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to null at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    strncpy(dest, src, size);
+    dest[size - 1] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+#else
+    char* line;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)malloc(INI_MAX_LINE);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, INI_MAX_LINE, stream) != NULL) {
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (*start == ';' || *start == '#') {
+            /* Per Python configparser, allow both ; and # comments at the
+               start of a line */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = lskip(value);
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+                error = lineno;
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}

--- a/prboom2/src/ini.h
+++ b/prboom2/src/ini.h
@@ -1,0 +1,104 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef __INI_H__
+#define __INI_H__
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See http://code.google.com/p/inih/issues/detail?id=21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Maximum line length for any line in INI file. */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INI_H__ */

--- a/prboom2/src/umapinfo.c
+++ b/prboom2/src/umapinfo.c
@@ -437,7 +437,7 @@ static void parse_boss_action(const char *boss_action, int *type,
         );
     }
 
-    *tag = convert_bossaction_int("Tag", startptr, &endptr);
+    *tag = convert_bossaction_int("Tag", startptr, NULL);
 }
 
 static int ini_value_handler(void *user, const char *map_name,

--- a/prboom2/src/umapinfo.c
+++ b/prboom2/src/umapinfo.c
@@ -594,7 +594,7 @@ static int ini_value_handler(void *user, const char *map_name,
 //
 // -----------------------------------------------
 
-int ParseUMapInfo(const char *buffer, size_t length) {
+void UMI_Parse(const char *buffer, size_t length) {
     size_t i;
 
     // must reallocate to append a 0 for strtod to work
@@ -665,8 +665,6 @@ int ParseUMapInfo(const char *buffer, size_t length) {
     }
 
     free(newbuffer);
-
-    return 1;
 }
 
 UMIMapEntry* UMI_LookupMapInfo(const char *map_name) {

--- a/prboom2/src/umapinfo.h
+++ b/prboom2/src/umapinfo.h
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 //
-// Copyright 2017 Christoph Oelckers
+// Copyright 2017 Christoph Oelckers, Charles Gunyon
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
@@ -20,74 +20,43 @@
 #ifndef __UMAPINFO_H
 #define __UMAPINFO_H
 
-enum
-{
-	TYPE_NUMBER,
-	TYPE_STRING,
-	TYPE_IDENTIFIER
+typedef struct BossAction {
+    int type;
+    int special;
+    int tag;
+} UMIBossAction;
+
+struct UMIMapEntryStruct {
+    char *mapname;
+    char *levelname;
+    char *intertext;
+    char *intertextsecret;
+    char levelpic[9];
+    char nextmap[9];
+    char nextsecret[9];
+    char music[9];
+    char skytexture[9];
+    char endpic[9];
+    char exitpic[9];
+    char enterpic[9];
+    char interbackdrop[9];
+    char intermusic[9];
+    int partime;
+    int nointermission;
+    int numbossactions;
+    UMIBossAction *bossactions;
 };
 
-struct MapPropertyValue
-{
-	int type;
-	union 
-	{
-		double number;
-		char *string;
-	} v;
-};
+typedef struct UMIMapEntryStruct UMIMapEntry;
 
-struct MapProperty
-{
-	char *propertyname;
-	unsigned int valuecount;
-	struct MapPropertyValue *values;
-};
+typedef struct {
+    size_t len;
+    UMIMapEntry *maps;
+} UMIMapList;
 
-struct BossAction
-{
-	int type;
-	int special;
-	int tag;
-};
+extern UMIMapList umi_maps;
 
-struct MapEntry
-{
-	char *mapname;
-	char *levelname;
-	char *intertext;
-	char *intertextsecret;
-	char levelpic[9];
-	char nextmap[9];
-	char nextsecret[9];
-	char music[9];
-	char skytexture[9];
-	char endpic[9];
-	char exitpic[9];
-	char enterpic[9];
-	char interbackdrop[9];
-	char intermusic[9];
-	int partime;
-	int nointermission;
-	int numbossactions;
-
-	unsigned int propertycount;
-	struct MapProperty *properties;
-	struct BossAction *bossactions;
-};
-
-struct MapList
-{
-	unsigned int mapcount;
-	struct MapEntry *maps;
-};
-
-typedef void (*umapinfo_errorfunc)(const char *fmt, ...);	// this must not return!
-
-extern struct MapList Maps;
-
-int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc err);
-void FreeMapList();
-struct MapProperty *FindProperty(struct MapEntry *map, const char *name);
+void UMI_Parse(const char *buffer, size_t length);
+UMIMapEntry* UMI_LookupMapInfo(const char *map_name);
 
 #endif

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -44,6 +44,7 @@
 #include "lprintf.h"  // jff 08/03/98 - declaration of lprintf
 #include "r_draw.h"
 #include "hu_stuff.h"
+#include "umapinfo.h"
 
 // Ty 03/17/98: flag that new par times have been loaded in d_deh
 extern dboolean deh_pars;


### PR DESCRIPTION
Hey I used an INI library ([this one](https://github.com/benhoyt/inih)) and tweaked the format into INI format.  It's even ever so slightly smaller!  I also namespaced things a little differently; I thought maybe UMAPINFO shouldn't use up things like Maps and MapEntry.

I updated the autoconf build system; I don't have VS* so I didn't do anything w/ that, but all that's needed is to add ini.c.  It compiles.  I don't feel like creating a test UMAPINFO lump so I don't know how it works, but it's a start.

Just a P.S.: PrBoom+ doesn't use tabs, and you're leaving tabs everywhere.