### PR TITLE
Intermission text handling code rewrite, missing underscore fix

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1770,11 +1770,11 @@ static uint_64_t getConvertedDEHBits(uint_64_t bits) {
 //---------------------------------------------------------------------------
 // Helper to preserve the newly added flags
 //---------------------------------------------------------------------------
-static void setFlags(int miindex, uint64_t value)
+static void setFlags(int miindex, uint_64_t value)
 {
 	mobjinfo_t *mi = &mobjinfo[miindex];
 	// Any flag above NOTARGET is not accessible here.
-	const uint64_t mask = MF_NOTARGET - 1;
+	const uint_64_t mask = MF_NOTARGET - 1;
 	mi->flags = (mi->flags & ~mask) | (value & mask);
 	// MF_ISMONSTER must mirror MF_COUNTKILL, except for the Lost Soul
 	if ((mi->flags & MF_COUNTKILL) || miindex == MT_SKULL) mi->flags |= MF_ISMONSTER;

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -106,13 +106,10 @@ static char *ParseMultiString(Scanner &scanner, int error)
 		if (build == NULL) build = strdup(scanner.string);
 		else
 		{
-			size_t oldlen = strlen(build);
-			size_t newlen = oldlen + strlen(scanner.string) + 2;
-
-			build = (char*)realloc(build, newlen);
-			build[oldlen] = '\n';
-			strcpy(build + oldlen + 1, scanner.string);
-			build[newlen] = 0;
+			size_t newlen = strlen(build) + strlen(scanner.string) + 2; // strlen for both the existing text and the new line, plus room for one \n and one \0
+			build = (char*)realloc(build, newlen); // Prepare the destination memory for the below strcats
+			strcat(build, "\n"); // Replace the existing text's \0 terminator with a \n
+			strcat(build, scanner.string); // Concatenate the new line onto the existing text
 		}
 	} while (scanner.CheckToken(','));
 	return build;


### PR DESCRIPTION
Rewriting the intermission text handling code for UMAPINFO such that it no longer crashes on my machine when the realloc() is hit. Also, fixing a missing underscore in "uint_64_t" in d_deh.c (was uint64_t) that prevented compilation.

Signed-off-by: Shadow Hog <shadow.hog@verizon.net>