### PR TITLE
fix TRANMAP caching

### DIFF
--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -431,7 +431,7 @@ void R_InitTranMap(int progress)
       int fnlen;
       struct {
         unsigned char pct;
-        unsigned char playpal[256];
+        unsigned char playpal[256*3];
       } cache;
       FILE *cachefp;
 
@@ -510,7 +510,7 @@ void R_InitTranMap(int progress)
           if ((cachefp = fopen(fname,"wb")) != NULL) // write out the cached translucency map
             {
               cache.pct = tran_filter_pct;
-              memcpy(cache.playpal, playpal, 256);
+              memcpy(cache.playpal, playpal, sizeof cache.playpal);
               fseek(cachefp, 0, SEEK_SET);
               fwrite(&cache, 1, sizeof cache, cachefp);
               fwrite(main_tranmap, 256, 256, cachefp);


### PR DESCRIPTION
When reading a TRANMAP lump in from a file, only the first 256 bytes
of the current palette are compared to the palette for which the
TRANMAP was created. An entire palette, though, consists of 256 RGB
tripel and is thus 3*256 bytes long. Thus, only the first third of
both palettes are compared and if these happen to match, translucency
will look glitched.

Fix this by comparing and writing out the entire palette to the cache
file.