### PR TITLE
Use bindir to configure gamesdir

### DIFF
--- a/prboom2/configure.ac
+++ b/prboom2/configure.ac
@@ -52,6 +52,10 @@ then
 fi
 AM_WITH_DMALLOC
 
+dnl --- Enable bindir support
+AC_ARG_ENABLE([bindir],AC_HELP_STRING([--enable-bindir],[Use bindir to configure game executable installation path]))
+AM_CONDITIONAL(DISABLE_BINDIR,test "x$enable_bindir" = "xno")
+
 dnl --- Try for processor optimisations
 AC_CPU_OPTIMISATIONS
 

--- a/prboom2/src/Makefile.am
+++ b/prboom2/src/Makefile.am
@@ -8,7 +8,10 @@
 
 SUBDIRS = SDL POSIX MAC PCSOUND TEXTSCREEN MUSIC   
 
-gamesdir=$(prefix)/games
+if DISABLE_BINDIR
+bindir=$(prefix)/games
+endif
+gamesdir=$(bindir)
 
 if BUILD_SERVER
 games_PROGRAMS = prboom-plus prboom-plus-game-server


### PR DESCRIPTION
Default bindir to `$(prefix)/games` and allow configuration of gamesdir
via bindir.

This should allow users to install PrBoom+ on systems that restrict access to the default `/usr/games` directory. See https://github.com/chocolate-doom/chocolate-doom/pull/635 for more background.