### PR TITLE
fix Doom 1 level progression by setting nextep to epsd

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1608,7 +1608,7 @@ void G_DoCompleted (void)
   }
 
   wminfo.didsecret = players[consoleplayer].didsecret;
-  wminfo.epsd = gameepisode -1;
+  wminfo.nextep = wminfo.epsd = gameepisode -1;
   wminfo.last = gamemap -1;
 
   // wminfo.next is 0 biased, unlike gamemap


### PR DESCRIPTION
Not sure if this is the universal solution, but at least it fixes the
most common i.e. non-UMAPINFO case.

Fixes: #21