### PR TITLE
fullscreen desktop for the software renderer

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1167,6 +1167,10 @@ void I_UpdateVideoMode(void)
     init_flags = SDL_WINDOW_OPENGL;
   }
 
+  // Fullscreen desktop for software renderer only - DTIED
+  if (desired_fullscreen && V_GetMode() != VID_MODEGL)
+    init_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+  else
   if ( desired_fullscreen )
     init_flags |= SDL_WINDOW_FULLSCREEN;
 

--- a/prboom2/src/i_capture.c
+++ b/prboom2/src/i_capture.c
@@ -78,6 +78,8 @@ int cap_frac;
 // %f filename passed to -viddump
 // %% single percent sign
 // TODO: add aspect ratio information
+//
+// Modified to work with SDL2 resizeable window and fullscreen desktop - DTIED
 static int parsecommand (char *out, const char *in, int len)
 {
   int i;
@@ -86,13 +88,14 @@ static int parsecommand (char *out, const char *in, int len)
   {
     if (*in == '%')
     {
+      I_UpdateRenderSize(); // Handle potential resolution scaling - DTIED
       switch (in[1])
       {
         case 'w':
-          i = doom_snprintf (out, len, "%u", REAL_SCREENWIDTH);
+          i = doom_snprintf (out, len, "%u", renderW);
           break;
         case 'h':
-          i = doom_snprintf (out, len, "%u", REAL_SCREENHEIGHT);
+          i = doom_snprintf (out, len, "%u", renderH);
           break;
         case 's':
           i = doom_snprintf (out, len, "%u", snd_samplerate);
@@ -551,6 +554,7 @@ void I_CapturePrep (const char *fn)
 
 // capture a single frame of video (and corresponding audio length)
 // and send it to pipes
+// Modified to work with SDL2 resizeable window and fullscreen desktop - DTIED
 void I_CaptureFrame (void)
 {
   unsigned char *snd;
@@ -579,7 +583,7 @@ void I_CaptureFrame (void)
   vid = I_GrabScreen ();
   if (vid)
   {
-    if (fwrite (vid, REAL_SCREENWIDTH * REAL_SCREENHEIGHT * 3, 1, videopipe.f_stdin) != 1)
+    if (fwrite (vid, renderW * renderH * 3, 1, videopipe.f_stdin) != 1)
       lprintf(LO_WARN, "I_CaptureFrame: error writing videopipe.\n");
     //free (vid); // static buffer
   }

--- a/prboom2/src/i_video.h
+++ b/prboom2/src/i_video.h
@@ -102,6 +102,10 @@ void I_StartFrame (void);
 extern int use_fullscreen;  /* proff 21/05/2000 */
 extern int desired_fullscreen; //e6y
 
+void I_UpdateRenderSize(void);	// Handle potential
+extern int renderW;		// resolution scaling
+extern int renderH;		// - DTIED
+
 // Set the process affinity mask so that all threads
 extern int process_affinity_mask;
 // Priority class for the prboom-plus process


### PR DESCRIPTION
This ports over the main feature of DTIED's own fork at
https://github.com/DerTodIstEinDandy/PrBoom-Plus-Fullscreen-Desktop

No need to change the physical resolution of the screen anymore,
if we can scale game content to its own native resolution.

Fixes #30.