### PR TITLE
disable the "popping skull player death" easter egg

### DIFF
--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -646,12 +646,14 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   mobj_t     *mo;
   dboolean   e6y = false;
   
+#if 0
   if (target->player && source && target->health < -target->info->spawnhealth &&
     !demorecording && !demoplayback)
   {
     angle_t ang = R_PointToAngle2(target->x, target->y, source->x, source->y) - target->angle;
     e6y = (ang > (unsigned)(ANG180 - ANG45) && ang < (unsigned)(ANG180 + ANG45));
   }
+#endif
 
   target->flags &= ~(MF_SHOOTABLE|MF_FLOAT|MF_SKULLFLY);
 


### PR DESCRIPTION
For quite some time, PrBoom+ contains an easter egg that features a
very special player death, where the camera is detached from the
player's body and moved away from it to provide view of its own gibbed
corpse. The conditions for reaching this death sequence are quite
abscure and it is, of course, entirely disabled during demo recording
and playback.

However, now there is report by some user who managed to reach the exit
line in TNT Map26 by performing a death slide by unknowingly using
this hidden death sequence. Of course, this user wan't able to record
a demo of himself doing this, because then this sequence is disabled.
This lead to a lot of confusion and guessing around in the
corresponding thread:

https://www.doomworld.com/forum/topic/111130-tnt-map-26-ballistyx-possibly-a-new-skip/

I'd suggest to leave all the code intact, but disable this death
sequence entirely. While it was probably meant as a funny easter egg,
the conditions to reproduce it are just too obscure and leave too many
open questions, especially for a port that is to be considered the
reference in demo compatibility - and thus reproducibility. So far,
this little feature has led to nothing but confusion and uncertainty.