### PR TITLE
Enable loading 16 bit RIFF wavs in .wads.

### DIFF
--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -112,6 +112,9 @@ typedef struct
   // ... and a 0.16 bit remainder of last step.
   unsigned int stepremainder;
   unsigned int samplerate;
+  unsigned int bits;
+  float alpha;
+  int prevS;
   // The channel data pointers, start and end.
   const unsigned char *data;
   const unsigned char *enddata;
@@ -166,21 +169,55 @@ static void stopchan(int i)
 //
 static int addsfx(int sfxid, int channel, const unsigned char *data, size_t len)
 {
+  channel_info_t *ci = channelinfo + channel;
+  float rc, dt;
+
   stopchan(channel);
 
-  channelinfo[channel].data = data;
-  /* Set pointer to end of raw data. */
-  channelinfo[channel].enddata = channelinfo[channel].data + len - 1;
-  channelinfo[channel].samplerate = (channelinfo[channel].data[3] << 8) + channelinfo[channel].data[2];
-  channelinfo[channel].data += 8; /* Skip header */
+  if (strncmp(data, "RIFF", 4) == 0 && strncmp(data + 8, "WAVEfmt ", 8) == 0)
+  {
+    // FIXME: can't handle stereo wavs
+    // ci->channels = data[22] | (data[23] << 8);
+    ci->samplerate = data[24] | (data[25] << 8) | (data[26] << 16) 
+                   | (data[27] << 24);
+    ci->bits = data[34] | (data[35] << 8);
+    ci->data = data + 44;
+    ci->enddata = data + 44 + (data[40] | (data[41] << 8) | (data[42] << 16) 
+                            | (data[43] << 24));
+    if (ci->enddata > data + len - 2)
+      ci->enddata = data + len - 2;
+  }
+  else
+  {
+    ci->samplerate = (data[3] << 8) + data[2];
+    ci->bits = 8;
+    ci->data = data + 8;
+    ci->enddata = data + len - 1;
+  }
 
-  channelinfo[channel].stepremainder = 0;
+  ci->prevS = 0;
+
+  // Filter from chocolate doom i_sdlsound.c 682-695
+  // Low-pass filter for cutoff frequency f:
+  //
+  // For sampling rate r, dt = 1 / r
+  // rc = 1 / 2*pi*f
+  // alpha = dt / (rc + dt)
+
+  // Filter to the half sample rate of the original sound effect
+  // (maximum frequency, by nyquist)
+
+  dt = 1.0f / snd_samplerate;
+  rc = 1.0f / (3.14f * ci->samplerate);
+  ci->alpha = dt / (rc + dt);
+
+  ci->stepremainder = 0;
   // Should be gametic, I presume.
-  channelinfo[channel].starttime = gametic;
+  ci->starttime = gametic;
 
   // Preserve sound SFX id,
   //  e.g. for avoiding duplicates of chainsaw.
-  channelinfo[channel].id = sfxid;
+  ci->id = sfxid;
 
   return channel;
 }
@@ -497,20 +534,34 @@ static void I_UpdateSound(void *unused, Uint8 *stream, int len)
     //  as well. Thus loop those  channels.
     for ( chan = 0; chan < numChannels; chan++ )
     {
+      channel_info_t *ci = channelinfo + chan;
+
       // Check channel, if active.
-      if (channelinfo[chan].data)
+      if (ci->data)
       {
+        int s;
         // Get the raw data from the channel.
         // no filtering
-        //int s = channelinfo[chan].data[0] * 0x10000 - 0x800000;
+        //s = ci->data[0] * 0x10000 - 0x800000;
 
         // linear filtering
         // the old SRC did linear interpolation back into 8 bit, and then expanded to 16 bit.
         // this does interpolation and 8->16 at same time, allowing slightly higher quality
-        int s = ((unsigned int)channelinfo[chan].data[0] * (0x10000 - channelinfo[chan].stepremainder))
-              + ((unsigned int)channelinfo[chan].data[1] * (channelinfo[chan].stepremainder))
-              - 0x800000; // convert to signed
+        if (ci->bits == 16)
+        {
+          s = (short)(ci->data[0] | (ci->data[1] << 8)) * (255 - (ci->stepremainder >> 8))
+            + (short)(ci->data[2] | (ci->data[3] << 8)) * (ci->stepremainder >> 8);
+        }
+        else
+        {
+          s = (ci->data[0] * (0x10000 - ci->stepremainder))
+            + (ci->data[1] * (ci->stepremainder))
+            - 0x800000; // convert to signed
+        }
 
+        // lowpass
+        s = ci->prevS + ci->alpha * (s - ci->prevS);
+        ci->prevS = s;
 
         // Add left and right part
         //  for this channel (sound)
@@ -519,18 +570,23 @@ static void I_UpdateSound(void *unused, Uint8 *stream, int len)
 
         // full loudness (vol=127) is actually 127/191
 
-        dl += channelinfo[chan].leftvol * s / 49152;  // >> 15;
-        dr += channelinfo[chan].rightvol * s / 49152; // >> 15;
+        dl += ci->leftvol * s / 49152;  // >> 15;
+        dr += ci->rightvol * s / 49152; // >> 15;
 
         // Increment index ???
-        channelinfo[chan].stepremainder += channelinfo[chan].step;
+        ci->stepremainder += ci->step;
+
         // MSB is next sample???
-        channelinfo[chan].data += channelinfo[chan].stepremainder >> 16;
+        if (ci->bits == 16)
+          ci->data += (ci->stepremainder >> 16) * 2;
+        else
+          ci->data += ci->stepremainder >> 16;
+
         // Limit to LSB???
-        channelinfo[chan].stepremainder &= 0xffff;
+        ci->stepremainder &= 0xffff;
 
         // Check whether we are done.
-        if (channelinfo[chan].data >= channelinfo[chan].enddata)
+        if (ci->data >= ci->enddata)
           stopchan(chan);
       }
     }


### PR DESCRIPTION
This pull request contains just enough changes to get https://www.doomworld.com/forum/topic/110822-doom-sound-bulb-hd-sounds-that-stay-true-to-the-original/ to work.

It also hacks in a low-pass filter borrowed from chocolate doom so upscaling old audio doesn't sound too horrible.

Also `samplerate` in `prboom-plus.cfg` defaults to `22050`, someone might want to raise that a bit, but everyone's configs already exist, so that might be a bit of a problem.