### PR TITLE
unconditionally build with DOGS support

### DIFF
--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -88,10 +88,8 @@ int default_monster_infighting=1;
 int monster_friction=1;       // killough 10/98: monsters affected by friction
 int default_monster_friction=1;
 
-#ifdef DOGS
 int dogs, default_dogs;         // killough 7/19/98: Marine's best friend :)
 int dog_jumping, default_dog_jumping;   // killough 10/98
-#endif
 
 // killough 8/8/98: distance friends tend to move towards players
 int distfriend = 128, default_distfriend = 128;

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -330,10 +330,8 @@ extern int default_weapon_recoil;
 extern int player_bobbing;  // whether player bobs or not   // phares 2/25/98
 extern int default_player_bobbing;  // killough 3/1/98: make local to each game
 
-#ifdef DOGS
 extern int dogs, default_dogs;     // killough 7/19/98: Marine's best friend :)
 extern int dog_jumping, default_dog_jumping;   // killough 10/98
-#endif
 
 /* killough 8/8/98: distance friendly monsters tend to stay from player */
 extern int distfriend, default_distfriend;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2502,16 +2502,13 @@ void G_Compatibility(void)
     monster_friction = 0;
     help_friends = 0;
 
-#ifdef DOGS
     dogs = 0;
     dog_jumping = 0;
-#endif
 
     monkeys = 0;
   }
 }
 
-#ifdef DOGS
 /* killough 7/19/98: Marine's best friend :) */
 static int G_GetHelpers(void)
 {
@@ -2521,7 +2518,6 @@ static int G_GetHelpers(void)
     j = M_CheckParm ("-dogs");
   return j ? j+1 < myargc ? atoi(myargv[j+1]) : 1 : default_dogs;
 }
-#endif
 
 // killough 3/1/98: function to reload all the default parameter
 // settings before a new game begins
@@ -2545,10 +2541,8 @@ void G_ReloadDefaults(void)
 
   monster_infighting = default_monster_infighting; // killough 7/19/98
 
-#ifdef DOGS
   dogs = netgame ? 0 : G_GetHelpers();             // killough 7/19/98
   dog_jumping = default_dog_jumping;
-#endif
 
   distfriend = default_distfriend;                 // killough 8/8/98
 
@@ -3043,11 +3037,7 @@ byte *G_WriteOptions(byte *demo_p)
 
   *demo_p++ = monster_infighting;   // killough 7/19/98
 
-#ifdef DOGS
   *demo_p++ = dogs;                 // killough 7/19/98
-#else
-  *demo_p++ = 0;
-#endif
 
   *demo_p++ = 0;
   *demo_p++ = 0;
@@ -3063,11 +3053,7 @@ byte *G_WriteOptions(byte *demo_p)
 
   *demo_p++ = help_friends;             // killough 9/9/98
 
-#ifdef DOGS
   *demo_p++ = dog_jumping;
-#else
-  *demo_p++ = 0;
-#endif
 
   *demo_p++ = monkeys;
 
@@ -3137,11 +3123,7 @@ const byte *G_ReadOptions(const byte *demo_p)
     {
       monster_infighting = *demo_p++;   // killough 7/19/98
 
-#ifdef DOGS
       dogs = *demo_p++;                 // killough 7/19/98
-#else
-      demo_p++;
-#endif
 
       demo_p += 2;
 
@@ -3156,11 +3138,7 @@ const byte *G_ReadOptions(const byte *demo_p)
 
       help_friends = *demo_p++;          // killough 9/9/98
 
-#ifdef DOGS
       dog_jumping = *demo_p++;           // killough 10/98
-#else
-      demo_p++;
-#endif
 
       monkeys = *demo_p++;
 
@@ -3403,17 +3381,13 @@ void G_SaveRestoreGameOptions(int save)
     {1, 0, &player_bobbing},
     {1, 0, &demo_insurance},
     {1, 0, &monster_infighting},
-#ifdef DOGS
     {1, 0, &dogs},
-#endif
     {1, 0, &distfriend},
     {1, 0, &monster_backing},
     {1, 0, &monster_avoid_hazards},
     {1, 0, &monster_friction},
     {1, 0, &help_friends},
-#ifdef DOGS
     {1, 0, &dog_jumping},
-#endif
     {1, 0, &monkeys},
   
     {2, 0, (int*)&forceOldBsp},
@@ -3564,10 +3538,8 @@ const byte* G_ReadDemoHeaderEx(const byte *demo_p, size_t size, unsigned int par
 
       monster_infighting = 1;           // killough 7/19/98
 
-#ifdef DOGS
       dogs = 0;                         // killough 7/19/98
       dog_jumping = 0;                  // killough 10/98
-#endif
 
       monster_backing = 0;              // killough 9/8/98
 

--- a/prboom2/src/info.c
+++ b/prboom2/src/info.c
@@ -1098,7 +1098,6 @@ state_t states[NUMSTATES] = {
   {SPR_MISL,32770,6,A_Detonate,S_DETONATE3},  // S_DETONATE2
   {SPR_MISL,32771,10,NULL,S_NULL},            // S_DETONATE3
 
-#ifdef DOGS
   // killough 7/19/98: Marine's best friend :)
   {SPR_DOGS,0,10,A_Look,S_DOGS_STND2},  // S_DOGS_STND
   {SPR_DOGS,1,10,A_Look,S_DOGS_STND}, // S_DOGS_STND2
@@ -1127,36 +1126,6 @@ state_t states[NUMSTATES] = {
   {SPR_DOGS,10,5,NULL,S_DOGS_RAISE5}, // S_DOGS_RAISE4
   {SPR_DOGS,9,5,NULL,S_DOGS_RAISE6},  // S_DOGS_RAISE5
   {SPR_DOGS,8,5,NULL,S_DOGS_RUN1},  // S_DOGS_RAISE6
-#else
-  // if dogs are disabled, dummy states are required for dehacked compatibility
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_STND
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_STND2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN1
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN3
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN4
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN5
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN6
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN7
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RUN8
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_ATK1
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_ATK2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_ATK3
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_PAIN
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_PAIN2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE1
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE3
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE4
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE5
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_DIE6
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE1
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE2
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE3
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE4
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE5
-  {0,0,-1,NULL,S_NULL}, // S_DOGS_RAISE6
-#endif
 
   // add dummy beta bfg / lost soul frames for dehacked compatibility
   // fixes bug #1576151 (part 2)
@@ -4887,7 +4856,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     MF_NOBLOCKMAP,  // flags
     S_NULL          // raisestate
   },
-#ifdef DOGS
+
   // Marine's best friend :)      // killough 7/19/98
   {   // MT_DOGS
     888,   // doomednum
@@ -4914,7 +4883,6 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL, // flags
     S_DOGS_RAISE1   // raisestate
   },
-#endif
 
   // killough 7/11/98: this is the first of two plasma fireballs in the beta
   {   // MT_PLASMA1

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2996,15 +2996,11 @@ enum {
   enem_friction,
   enem_help_friends,
 
-#ifdef DOGS
   enem_helpers,
-#endif
 
   enem_distfriend,
 
-#ifdef DOGS
   enem_dog_jumping,
-#endif
 
   enem_end
 };
@@ -3029,7 +3025,6 @@ setup_menu_t enem_settings1[] =  // Enemy Settings screen
 
   {"Rescue Dying Friends",S_YESNO,m_null,E_X,E_Y+ enem_help_friends*8, {"help_friends"}},
 
-#ifdef DOGS
   // killough 7/19/98
   {"Number Of Single-Player Helper Dogs",S_NUM|S_LEVWARN,m_null,E_X,E_Y+ enem_helpers*8, {"player_helpers"}},
 
@@ -3037,7 +3032,6 @@ setup_menu_t enem_settings1[] =  // Enemy Settings screen
   {"Distance Friends Stay Away",S_NUM,m_null,E_X,E_Y+ enem_distfriend*8, {"friend_distance"}},
 
   {"Allow dogs to jump down",S_YESNO,m_null,E_X,E_Y+ enem_dog_jumping*8, {"dog_jumping"}},
-#endif
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -300,14 +300,12 @@ default_t defaults[] =
    def_bool,ss_weap, &allow_pushers},
   {"variable_friction",{&default_variable_friction},{1},0,1,
    def_bool,ss_weap, &variable_friction},
-#ifdef DOGS
   {"player_helpers",{&default_dogs}, {0}, 0, 3,
    def_bool, ss_enem },
   {"friend_distance",{&default_distfriend}, {128}, 0, 999,
    def_int, ss_enem, &distfriend},
   {"dog_jumping",{&default_dog_jumping}, {1}, 0, 1,
    def_bool, ss_enem, &dog_jumping},
-#endif
    /* End of MBF AI extras */
 
   {"sts_always_red",{&sts_always_red},{1},0,1, // no color changes on status bar

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -456,7 +456,6 @@ static dboolean P_SmartMove(mobj_t *actor)
   // dropoff==1 means always allow it, dropoff==2 means only up to 128 high,
   // and only if the target is immediately on the other side of the line.
 
-#ifdef DOGS
   // haleyjd: allow all friends of HelperType to also jump down
 
   if ((actor->type == MT_DOGS || (actor->type == (HelperThing-1) && actor->flags&MF_FRIEND))
@@ -466,7 +465,6 @@ static dboolean P_SmartMove(mobj_t *actor)
           actor->y - target->y) < FRACUNIT*144 &&
       P_Random(pr_dropoff) < 235)
     dropoff = 2;
-#endif
 
   if (!P_Move(actor, dropoff))
     return false;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1314,7 +1314,6 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
 
   if (thingtype <= 4 && thingtype > 0)  // killough 2/26/98 -- fix crashes
     {
-#ifdef DOGS
       // killough 7/19/98: Marine's best friend :)
       if (!netgame && thingtype > 1 && thingtype <= dogs+1 &&
     !players[thingtype-1].secretcount)
@@ -1341,7 +1340,6 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
     }
     goto spawnit;
   }
-#endif
 
     // save spots for respawning in coop games
     playerstarts[thingtype-1] = *mthing;
@@ -1414,9 +1412,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
     return NULL;
 
   // spawn it
-#ifdef DOGS
 spawnit:
-#endif
 
   x = mthing->x << FRACBITS;
   y = mthing->y << FRACBITS;

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -237,14 +237,12 @@ sfxinfo_t S_sfx[] = {
   { "skeatk", false, 70, 0, -1, -1, 0 },
   { "radio", false, 60, 0, -1, -1, 0 },
   
-#ifdef DOGS
   // killough 11/98: dog sounds
   { "dgsit",  false,   98, 0, -1, -1, 0 },
   { "dgatk",  false,   70, 0, -1, -1, 0 },
   { "dgact",  false,  120, 0, -1, -1, 0 },
   { "dgdth",  false,   70, 0, -1, -1, 0 },
   { "dgpain", false,   96, 0, -1, -1, 0 },
-#endif
 
   //e6y
   { "secret", false, 60, 0, -1, -1, 0 },

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -290,14 +290,12 @@ typedef enum {
   sfx_skeatk,
   sfx_radio,
 
-#ifdef DOGS
   /* killough 11/98: dog sounds */
   sfx_dgsit,
   sfx_dgatk,
   sfx_dgact,
   sfx_dgdth,
   sfx_dgpain,
-#endif
 
   //e6y
   sfx_secret,


### PR DESCRIPTION
This fixes the demo desyncs found in

EVIT24-832.lmp  EVIT30-250.lmp  va18-931.lmp  va24-1143.lmp

Has most probably been puzzled up by commit 923bb1b4e which already
unconditionally enabled this in src/info.[ch].