### PR TITLE
Add mouse strafe divisor setting

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -517,11 +517,6 @@ dboolean HaveMouseLook(void)
   return (viewpitch != 0);
 }
 
-int GetMouseStrafeDivisor(void)
-{
-  return movement_mousestrafedivisor;
-}
-
 void CheckPitch(signed int *pitch)
 {
   if(*pitch > maxViewPitch)

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -135,6 +135,7 @@ int movement_shorttics;
 int movement_mouselook;
 int movement_mouseinvert;
 int movement_maxviewpitch;
+int movement_mousestrafedivisor;
 int mouse_handler;
 int mouse_doubleclick_as_use;
 int render_fov = 90;
@@ -514,6 +515,11 @@ dboolean GetMouseLook(void)
 dboolean HaveMouseLook(void)
 {
   return (viewpitch != 0);
+}
+
+int GetMouseStrafeDivisor(void)
+{
+  return movement_mousestrafedivisor;
 }
 
 void CheckPitch(signed int *pitch)

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -210,7 +210,6 @@ void I_Init2(void);
 
 dboolean GetMouseLook(void);
 dboolean HaveMouseLook(void);
-int GetMouseStrafeDivisor(void);
 
 extern float viewPitch;
 extern dboolean transparentpresent;

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -123,6 +123,7 @@ extern int movement_shorttics;
 extern int movement_mouselook;
 extern int movement_mouseinvert;
 extern int movement_maxviewpitch;
+extern int movement_mousestrafedivisor;
 extern int mouse_handler;
 extern int mouse_doubleclick_as_use;
 extern int render_multisampling;
@@ -209,6 +210,7 @@ void I_Init2(void);
 
 dboolean GetMouseLook(void);
 dboolean HaveMouseLook(void);
+int GetMouseStrafeDivisor(void);
 
 extern float viewPitch;
 extern dboolean transparentpresent;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -695,7 +695,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   forward += mousey;
   if (strafe)
-    side += mousex / 4;       /* mead  Don't want to strafe as fast as turns.*/
+    side += mousex / GetMouseStrafeDivisor(); /* mead  Don't want to strafe as fast as turns.*/
   else
     cmd->angleturn -= mousex; /* mead now have enough dynamic range 2-10-00 */
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -695,7 +695,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   forward += mousey;
   if (strafe)
-    side += mousex / GetMouseStrafeDivisor(); /* mead  Don't want to strafe as fast as turns.*/
+    side += mousex / movement_mousestrafedivisor; /* mead  Don't want to strafe as fast as turns.*/
   else
     cmd->angleturn -= mousex; /* mead now have enough dynamic range 2-10-00 */
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3223,6 +3223,7 @@ setup_menu_t gen_settings3[] = { // General Settings screen2
   {"Enable Mouselook",            S_YESNO, m_null, G_X, G_Y+13*8, {"movement_mouselook"}, 0, 0, M_ChangeMouseLook},
   {"Invert Mouse",                S_YESNO, m_null, G_X, G_Y+14*8, {"movement_mouseinvert"}, 0, 0, M_ChangeMouseInvert},
   {"Max View Pitch",              S_NUM,   m_null, G_X, G_Y+15*8, {"movement_maxviewpitch"}, 0, 0, M_ChangeMaxViewPitch},
+  {"Mouse Strafe Divisor",        S_NUM,   m_null, G_X, G_Y+16*8, {"movement_mousestrafedivisor"}},
 
   {"<- PREV",S_SKIP|S_PREV, m_null,KB_PREV, KB_Y+20*8, {gen_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {gen_settings4}},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1012,6 +1012,8 @@ default_t defaults[] =
    def_bool,ss_stat},
   {"movement_maxviewpitch", {&movement_maxviewpitch},  {90},0,90,
    def_int,ss_stat},
+   {"movement_mousestrafedivisor", {&movement_mousestrafedivisor},  {4},1,512,
+    def_int,ss_stat},
   {"movement_mouseinvert", {&movement_mouseinvert},  {0},0,1,
    def_bool,ss_stat},
 


### PR DESCRIPTION
Hello :slightly_smiling_face: 

This PR adds a setting for the mouse strafe divisor (factor by which mouse strafe is reduced as compared to normal horizontal sensitivity), which is particularly important for speedrunners.

When performing certain tricks (e.g., unguided glides), it's helpful to line up using mouse strafe. Unfortunately, mouse strafe is extremely fast by default, making precise movement impossible, except for those with low mouse sensitivity.

A partial mitigation was already in the code base: dividing the strafe by 4. Since this value's relevance depends on a user's sensitivity, I think making it a setting is more natural and increases its usefulness.