### PR TITLE
Add stroller param

### DIFF
--- a/prboom2/doc/prboom-plus-usage.txt
+++ b/prboom2/doc/prboom-plus-usage.txt
@@ -189,6 +189,7 @@ Additional command-line parameters:
 "-aspect NxM" - for using a different aspect ratio; e.g. -aspect 5x4, -aspect 8x5 or -aspect 2x1.
 "-videodriver name" - for setting up the videodriver name that SDL will use. "windib" and "directx" are available for Windows. See SDL documentation for other platforms. "-videodriver default" can be used to force SDL behaviour by default.
 "-shorttics" - forces the same mouse behaviour as when recording (i.e. the converse of "-longtics")
+"-stroller" - removes ability to strafe and limits running speed (a speedrun category)
 "-resetgamma" - restores the original gamma after a crash
 "-exe chex" - causes the game to play like chex.exe (Chex Quest) - chex.wad and chex.deh required too
 "-geom NxM" [basic syntax] - for temporarily using a particular resolution without saving this in the cfg; e.g. -geom 1280x1024.

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -285,7 +285,7 @@ void e6y_InitCommandLine(void)
     avi_shot_fname = myargv[p + 1];
   stats_level = M_CheckParm("-levelstat");
 
-  if (stroller = M_CheckParm("-stroller"))
+  if ((stroller = M_CheckParm("-stroller")))
   {
     M_AddParam("-turbo");
     M_AddParam("50");

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -285,6 +285,12 @@ void e6y_InitCommandLine(void)
     avi_shot_fname = myargv[p + 1];
   stats_level = M_CheckParm("-levelstat");
 
+  if (stroller = M_CheckParm("-stroller"))
+  {
+    M_AddParam("-turbo");
+    M_AddParam("50");
+  }
+
   // TAS-tracers
   InitTracers();
 
@@ -825,6 +831,7 @@ int I_MessageBox(const char* text, unsigned int type)
 }
 
 int stats_level;
+int stroller;
 int numlevels = 0;
 int levels_max = 0;
 timetable_t *stats = NULL;

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -289,6 +289,7 @@ const char* WINError(void);
 #endif
 
 extern int stats_level;
+extern int stroller;
 void e6y_G_DoCompleted(void);
 void e6y_WriteStats(void);
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -726,6 +726,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     }
   }
 
+  if (stroller) side = 0;
+
   cmd->forwardmove += fudgef((signed char)forward);
   cmd->sidemove += side;
   cmd->angleturn = fudgea(cmd->angleturn);


### PR DESCRIPTION
You may or may not have heard about a speedrun category that has been gaining some popularity over the past year: stroller (it's now more active than nm 100s...).

The rules are: pacifist + no strafe + turbo 50

This PR adds a simple convenience parameter to the command line that sets turbo 50 and prevents strafing.

If you see this as too frivolous to add, I'll understand :wink: 