### PR TITLE
Improve boom random seed

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -43,6 +43,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <time.h>
 #include <signal.h>
 #ifdef _MSC_VER
 #define    F_OK    0    /* Check for file existence */
@@ -201,8 +202,7 @@ void I_GetTime_SaveMS(void)
  */
 unsigned long I_GetRandomTimeSeed(void)
 {
-/* This isnt very random */
-  return(SDL_GetTicks());
+  return (unsigned long)time(NULL);
 }
 
 /* cphipps - I_GetVersionString


### PR DESCRIPTION
One of the "features" of boom is that the random engine is seeded at the start so you get a different sequence of random numbers (in contrast to vanilla, which is fixed).

For some reason, in prboom+, the random seed was set up using the milliseconds since SDL initialization. As you can imagine, this means you only see a few different seeds.

Using `time(NULL)` isn't going to win any awards for randomness but I think it's satisfactory for this application.

Thanks to vita for bringing this up, because I forgot about it.