### PR TITLE
Fix Boom autoswitch behavior

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -152,6 +152,9 @@ int             totalleveltimes;      // CPhipps - total time for all completed 
 int             longtics;
 int             bytes_per_tic;
 
+dboolean boom_autoswitch;
+dboolean done_autoswitch;
+
 // e6y
 // There is a new command-line switch "-shorttics".
 // This makes it possible to practice routes and tricks
@@ -564,9 +567,14 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   //
   // killough 3/26/98, 4/2/98: fix autoswitch when no weapons are left
 
+  // Make Boom insert only a single weapon change command on autoswitch.
   if ((!demo_compatibility && players[consoleplayer].attackdown && // killough
-       !P_CheckAmmo(&players[consoleplayer])) || gamekeydown[key_weapontoggle])
+       !P_CheckAmmo(&players[consoleplayer])) && !done_autoswitch && boom_autoswitch ||
+       gamekeydown[key_weapontoggle])
+  {
     newweapon = P_SwitchWeapon(&players[consoleplayer]);           // phares
+    done_autoswitch = true;
+  }
   else
     {                                 // phares 02/26/98: Added gamemode checks
       if (next_weapon)

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -223,6 +223,9 @@ extern int shorttics;
 extern int longtics;
 extern int bytes_per_tic;
 
+extern dboolean boom_autoswitch;
+extern dboolean done_autoswitch;
+
 #define singleplayer (!demorecording && !demoplayback && !democontinue && !netgame)
 #define comperr(i) (default_comperr[i] && !demorecording && !demoplayback && !democontinue && !netgame)
 

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -261,6 +261,7 @@ default_t defaults[] =
    def_bool,ss_stat},
   {"demo_smoothturnsfactor", {&demo_smoothturnsfactor},  {6},1,SMOOTH_PLAYING_MAXFACTOR,
    def_int,ss_stat},
+  {"boom_autoswitch", {(int*)&boom_autoswitch}, {1}, 0, 1, def_bool, ss_none},
    
   {"Files",{NULL},{0},UL,UL,def_none,ss_none},
   /* cph - MBF-like wad/deh/bex autoload code */

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -371,6 +371,8 @@ void A_WeaponReady(player_t *player, pspdef_t *psp)
     angle &= FINEANGLES/2-1;
     psp->sy = WEAPONTOP + FixedMul(player->bob, finesine[angle]);
   }
+
+  done_autoswitch = false;
 }
 
 //


### PR DESCRIPTION
[My DW post](https://www.doomworld.com/forum/post/2061995):
> When you run out of ammo with cl9 or higher, PrBoom+ continuously tries to autoswitch to the most preferred weapon and doesn't let the player switch to what they want. E.g. I spent all my cells with the plasmagun and want to use the rocket launcher but the port inserts a bunch of commands to change to ssg (one can notice this by inspecting Boom or MBF demos in XDRE); I have to switch to it first and only then to RL.
