### PR TITLE
Include secret exit in levelstat

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -859,6 +859,13 @@ void e6y_G_DoCompleted(void)
   else
     sprintf(stats[numlevels].map,"E%iM%i",gameepisode,gamemap);
 
+  if (secretexit)
+  {
+    size_t end_of_string = strlen(stats[numlevels].map);
+    if (end_of_string < 15)
+      stats[numlevels].map[end_of_string] = 's';
+  }
+
   stats[numlevels].stat[TT_TIME]        = leveltime;
   stats[numlevels].stat[TT_TOTALTIME]   = totalleveltimes;
   stats[numlevels].stat[TT_TOTALKILL]   = totalkills;

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -197,6 +197,7 @@ extern int  joybspeed;
 
 extern int  defaultskill;      //jff 3/24/98 default skill
 extern dboolean haswolflevels;  //jff 4/18/98 wolf levels present
+extern dboolean secretexit;
 
 extern int  bodyquesize;       // killough 2/8/98: adustable corpse limit
 


### PR DESCRIPTION
The `-levelstat` parameter causes the port to print out a `levelstat.txt` file with map-by-map statistics. This is most useful for speedrunning (e.g., to confirm that you collected all secrets), and especially for automated checking of demos.

One thing missing from this file is information about the exit taken in a map.

This PR adds an `s` to the level name to signify when a secret exit was taken, which is the standard currently used in the community. For example, instead of `E1M3` it will now say `E1M3s` in the text file.