### PR TITLE
Add configurable quickstart window

### DIFF
--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -336,6 +336,9 @@ void NetUpdate(void)
     lastmadetic += newtics;
     if (ffmap) newtics++;
     while (newtics--) {
+      if (quickstart_window_ms > 0 && gametic == 0 && demorecording)
+        I_uSleep(quickstart_window_ms * 1000);
+
       I_StartTic();
       if (maketic - gametic > BACKUPTICS/2) break;
       

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -336,9 +336,6 @@ void NetUpdate(void)
     lastmadetic += newtics;
     if (ffmap) newtics++;
     while (newtics--) {
-      if (quickstart_window_ms > 0 && gametic == 0 && demorecording)
-        I_uSleep(quickstart_window_ms * 1000);
-
       I_StartTic();
       if (maketic - gametic > BACKUPTICS/2) break;
       

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -446,6 +446,9 @@ static const char *auto_shot_fname;
 
 static void D_DoomLoop(void)
 {
+  if (quickstart_window_ms > 0 && demorecording)
+    I_uSleep(quickstart_window_ms * 1000);
+
   for (;;)
     {
       WasRenderedInTryRunTics = false;

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -446,7 +446,7 @@ static const char *auto_shot_fname;
 
 static void D_DoomLoop(void)
 {
-  if (quickstart_window_ms > 0 && demorecording)
+  if (quickstart_window_ms > 0)
     I_uSleep(quickstart_window_ms * 1000);
 
   for (;;)

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -144,6 +144,7 @@ int render_paperitems;
 int render_wipescreen;
 int mouse_acceleration;
 int demo_overwriteexisting;
+int quickstart_window_ms;
 
 int showendoom;
 

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -131,6 +131,7 @@ extern int render_paperitems;
 extern int render_wipescreen;
 extern int mouse_acceleration;
 extern int demo_overwriteexisting;
+extern int quickstart_window_ms;
 
 extern int render_fov;
 extern int render_aspect;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3213,17 +3213,18 @@ setup_menu_t gen_settings3[] = { // General Settings screen2
   {"Overwrite Existing",          S_YESNO, m_null, G_X, G_Y+ 3*8, {"demo_overwriteexisting"}},
   {"Smooth Demo Playback",        S_YESNO, m_null, G_X, G_Y+ 4*8, {"demo_smoothturns"}, 0, 0, M_ChangeDemoSmoothTurns},
   {"Smooth Demo Playback Factor", S_NUM,   m_null, G_X, G_Y+ 5*8, {"demo_smoothturnsfactor"}, 0, 0, M_ChangeDemoSmoothTurns},
+  {"Quickstart Window (ms)",      S_NUM,   m_null, G_X, G_Y+6*8, {"quickstart_window_ms"}},
 
-  {"Movements",                   S_SKIP|S_TITLE,m_null,G_X, G_Y+7*8},
-  {"Permanent Strafe50",          S_YESNO, m_null, G_X, G_Y+ 8*8, {"movement_strafe50"}, 0, 0, M_ChangeSpeed},
+  {"Movements",                   S_SKIP|S_TITLE,m_null,G_X, G_Y+8*8},
+  {"Permanent Strafe50",          S_YESNO, m_null, G_X, G_Y+ 9*8, {"movement_strafe50"}, 0, 0, M_ChangeSpeed},
 
-  {"Mouse",                       S_SKIP|S_TITLE,m_null, G_X, G_Y+11*8},
-  {"Dbl-Click As Use",            S_YESNO, m_null, G_X, G_Y+12*8, {"mouse_doubleclick_as_use"}},
+  {"Mouse",                       S_SKIP|S_TITLE,m_null, G_X, G_Y+12*8},
+  {"Dbl-Click As Use",            S_YESNO, m_null, G_X, G_Y+13*8, {"mouse_doubleclick_as_use"}},
 
-  {"Enable Mouselook",            S_YESNO, m_null, G_X, G_Y+13*8, {"movement_mouselook"}, 0, 0, M_ChangeMouseLook},
-  {"Invert Mouse",                S_YESNO, m_null, G_X, G_Y+14*8, {"movement_mouseinvert"}, 0, 0, M_ChangeMouseInvert},
-  {"Max View Pitch",              S_NUM,   m_null, G_X, G_Y+15*8, {"movement_maxviewpitch"}, 0, 0, M_ChangeMaxViewPitch},
-  {"Mouse Strafe Divisor",        S_NUM,   m_null, G_X, G_Y+16*8, {"movement_mousestrafedivisor"}},
+  {"Enable Mouselook",            S_YESNO, m_null, G_X, G_Y+14*8, {"movement_mouselook"}, 0, 0, M_ChangeMouseLook},
+  {"Invert Mouse",                S_YESNO, m_null, G_X, G_Y+15*8, {"movement_mouseinvert"}, 0, 0, M_ChangeMouseInvert},
+  {"Max View Pitch",              S_NUM,   m_null, G_X, G_Y+16*8, {"movement_maxviewpitch"}, 0, 0, M_ChangeMaxViewPitch},
+  {"Mouse Strafe Divisor",        S_NUM,   m_null, G_X, G_Y+17*8, {"movement_mousestrafedivisor"}},
 
   {"<- PREV",S_SKIP|S_PREV, m_null,KB_PREV, KB_Y+20*8, {gen_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {gen_settings4}},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -941,6 +941,8 @@ default_t defaults[] =
    def_str,ss_none},
   {"demo_overwriteexisting", {&demo_overwriteexisting},  {1},0,1,
    def_bool,ss_stat},
+  {"quickstart_window_ms", {&quickstart_window_ms},  {0},0,1000,
+   def_int,ss_stat},
 
   {"Prboom-plus game settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"movement_strafe50", {&movement_strafe50},  {0},0,1,


### PR DESCRIPTION
## Background
If you perform some inputs during the melt when you launch doom, then they will "stack up" and execute after the melt instantly - e.g., turn and straferun during melt will become one frame of turning + straferunning followed by a series of straferunning frames before the player has control again. The details of this action depend on the source port. However, the first frame will be empty, because of how input is read before the melt starts. However, you _can_ get first frame movement if your timing is precise enough. This is called getting a "quickstart" in the speedrunning community. 

The problem is that how precise you need to be depends on both hardware and the source port. Thus, some users are at a disadvantage relative to others. For most players this isn't relevant, but for the players pushing the human limit, one frame makes all the difference (e1m1 in 8.97 comes to mind, and doom 2 map 1 -nomonsters is at 5.03 right now).

## Comparison
Right now crispy doom is the "easy" port for this. You can tell you execute quickstart when it shows a different angle during the melt than the default one for a given map, and the way to execute it is quite consistent. With current prboom+ I can execute a quickstart, but the window is extremely tight. 4shockblast can't get it at all, but he could on an older computer just fine. The point is that this isn't a skill question, but rather a question of hardware and software.

## Goal
The goal of this PR is to take out the hardware / software dependent element in executing a quickstart, so that every player is on an even playing field.

## Solution
I've added an option to the settings that simply adds a delay to the first gametic before reading the input. This simulates a slower startup and only affects the game during demo recording.