### PR TITLE
Forbid 180 while strafe is on

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -496,7 +496,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
                                                                   //    |
   if (gamekeydown[key_reverse])                                   //    V
     {
-      cmd->angleturn += QUICKREVERSE;                             //    ^
+      if (!strafe)
+        cmd->angleturn += QUICKREVERSE;                           //    ^
       gamekeydown[key_reverse] = false;                           //    |
     }                                                             // phares
 


### PR DESCRIPTION
This is a small patch.

The "turn 180" keybind injects a perfect 180 degree turn (the original motivation was to help keyboard-only players, afaik).

Unfortunately, this action doesn't check for the "strafe on" status, which means you can execute it while in a state where you shouldn't be able to turn.

This is especially problematic during sr50 - you can produce the illegal input of a turn frame during sr50.

I just added a condition that the turn only executes if strafe is off.