### PR TITLE
Fix compilation when CMAKE_C_FLAGS is set

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -166,7 +166,7 @@ if (MSVC)
     add_definitions("/D_CRT_SECURE_NO_WARNINGS")
 else()
     set(CMAKE_C_FLAGS
-        ${CMAKE_C_FLAGS} "\
+        "${CMAKE_C_FLAGS} \
         -Wall -Wextra -Wno-missing-field-initializers -Wwrite-strings -Wundef \
         -Wbad-function-cast -Wcast-align -Wcast-qual -Wdeclaration-after-statement \
         -Wpointer-arith -Wno-unused -Wno-switch -Wno-sign-compare -Wno-pointer-sign \


### PR DESCRIPTION
CMake would insert a semicolon between the contents of CMAKE_C_FLAGS, and the newly-appended flags. This goes unnoticed if CMAKE_C_FLAGS isn't set to anything, but when it is, it causes the compiler to throw a fit. I encountered this while trying to make an Arch Linux package (which I wasn't able to, since the CMake script lacks install targets).