### PR TITLE
Show Extended Help screen when pressing the Help key.

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4054,7 +4054,15 @@ void M_InitExtendedHelp(void)
     i = W_CheckNumForName(namebfr);
     if (i == -1) {
       if (extended_help_count) {
-        /* Update consolidated help menu */
+        /* The Extended Help menu is accessed using the
+         * Help hotkey (F1) or the "Read This!" menu item.
+         *
+         * If Extended Help screens are present, use the
+         * Extended Help routine when either the F1 Help Menu
+         * or the "Read This!" menu items are accessed.
+         *
+         * See also: https://www.doomworld.com/forum/topic/111465-boom-extended-help-screens-an-undocumented-feature/
+         */
           HelpMenu[0].routine = M_ExtHelp;
         if (gamemode == commercial) {
           ExtHelpDef.prevMenu  = &ReadDef1; /* previous menu */

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4054,13 +4054,15 @@ void M_InitExtendedHelp(void)
     i = W_CheckNumForName(namebfr);
     if (i == -1) {
       if (extended_help_count) {
+        /* Update consolidated help menu */
+          HelpMenu[0].routine = M_ExtHelp;
         if (gamemode == commercial) {
           ExtHelpDef.prevMenu  = &ReadDef1; /* previous menu */
           ReadMenu1[0].routine = M_ExtHelp;
-  } else {
+        } else {
           ExtHelpDef.prevMenu  = &ReadDef2; /* previous menu */
           ReadMenu2[0].routine = M_ExtHelp;
-  }
+        }
       }
       return;
     }


### PR DESCRIPTION
This PR proposes a fix to a very old bug that broke the Extended Help functionality of Boom.

After the final Boom 2.02 release, around 10/1998 the Help menu accessed by the F1 hotkey was refactored to a single menu definition instead of calling versions of the "Read This!" menu item.

However, the code that installs the Extended Help handler was not updated to redirect calls to the new Help menu. This effectively made it impossible to use Extended Help without a "Read This!" menu item.

This PR adds the missing call to install the handler and restores the F1 hotkey functionality as it was in the Boom releases.