### PR TITLE
fix heap buffer overflows in UDP code (CVE-2019-20797)

### DIFF
--- a/prboom2/src/SDL/i_network.c
+++ b/prboom2/src/SDL/i_network.c
@@ -240,7 +240,7 @@ size_t I_GetPacket(packet_header_t* buffer, size_t buflen)
   checksum=buffer->checksum;
   buffer->checksum=0;
   if ( (status!=0) && (len>0)) {
-    byte psum = ChecksumPacket(buffer, udp_packet->len);
+    byte psum = ChecksumPacket(buffer, len); // https://logicaltrust.net/blog/2019/10/prboom1.html
 /*    fprintf(stderr, "recvlen = %u, stolen = %u, csum = %u, psum = %u\n",
   udp_packet->len, len, checksum, psum); */
     if (psum == checksum) return len;

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -351,7 +351,7 @@ void NetUpdate(void)
       int sendtics;
       remotesend -= xtratics;
       if (remotesend < 0) remotesend = 0;
-      sendtics = MAX(maketic - remotesend, 128); // limit number of sent tics (CVE-2019-20797)
+      sendtics = MIN(maketic - remotesend, 128); // limit number of sent tics (CVE-2019-20797)
       {
   size_t pkt_size = sizeof(packet_header_t) + 2 + sendtics * sizeof(ticcmd_t);
   packet_header_t *packet = Z_Malloc(pkt_size, PU_STATIC, NULL);

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -351,7 +351,7 @@ void NetUpdate(void)
       int sendtics;
       remotesend -= xtratics;
       if (remotesend < 0) remotesend = 0;
-      sendtics = maketic - remotesend;
+      sendtics = MAX(maketic - remotesend, 35); // never send more than one second worth of tics (CVE-2019-20797)
       {
   size_t pkt_size = sizeof(packet_header_t) + 2 + sendtics * sizeof(ticcmd_t);
   packet_header_t *packet = Z_Malloc(pkt_size, PU_STATIC, NULL);

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -351,7 +351,7 @@ void NetUpdate(void)
       int sendtics;
       remotesend -= xtratics;
       if (remotesend < 0) remotesend = 0;
-      sendtics = MAX(maketic - remotesend, 35); // never send more than one second worth of tics (CVE-2019-20797)
+      sendtics = MAX(maketic - remotesend, 128); // limit number of sent tics (CVE-2019-20797)
       {
   size_t pkt_size = sizeof(packet_header_t) + 2 + sendtics * sizeof(ticcmd_t);
   packet_header_t *packet = Z_Malloc(pkt_size, PU_STATIC, NULL);

--- a/prboom2/src/d_server.c
+++ b/prboom2/src/d_server.c
@@ -682,7 +682,7 @@ int main(int argc, char** argv)
       int tics;
       if (lowtic <= remoteticto[i]) continue;
       if ((remoteticto[i] -= xtratics) < 0) remoteticto[i] = 0;
-      tics = lowtic - remoteticto[i];
+      tics = MAX(lowtic - remoteticto[i], 35); // never send more than one second worth of tics (CVE-2019-20797)
       {
         byte *p;
         packet = malloc(sizeof(packet_header_t) + 1 +

--- a/prboom2/src/d_server.c
+++ b/prboom2/src/d_server.c
@@ -682,7 +682,7 @@ int main(int argc, char** argv)
       int tics;
       if (lowtic <= remoteticto[i]) continue;
       if ((remoteticto[i] -= xtratics) < 0) remoteticto[i] = 0;
-      tics = MAX(lowtic - remoteticto[i], 128); // limit number of sent tics (CVE-2019-20797)
+      tics = MIN(lowtic - remoteticto[i], 128); // limit number of sent tics (CVE-2019-20797)
       {
         byte *p;
         packet = malloc(sizeof(packet_header_t) + 1 +

--- a/prboom2/src/d_server.c
+++ b/prboom2/src/d_server.c
@@ -682,7 +682,7 @@ int main(int argc, char** argv)
       int tics;
       if (lowtic <= remoteticto[i]) continue;
       if ((remoteticto[i] -= xtratics) < 0) remoteticto[i] = 0;
-      tics = MAX(lowtic - remoteticto[i], 35); // never send more than one second worth of tics (CVE-2019-20797)
+      tics = MAX(lowtic - remoteticto[i], 128); // limit number of sent tics (CVE-2019-20797)
       {
         byte *p;
         packet = malloc(sizeof(packet_header_t) + 1 +


### PR DESCRIPTION
* Limit length of buffer passed over to ChecksumPacket().
  Patch taken from the OP at https://logicaltrust.net/blog/2019/10/prboom1.html

* Never send more than one second worth of tics (i.e. 35) in both the
  main() routine in d_server.c and NetUpdate() in d_client.c.
  This avoids overflows of the allocated UDF buffer with a fixed size
  of 10000 bytes. Theoretically, up to about 35 seconds could be sent in the
  client code and up to about 7 seconds in the server code, but the
  network game would be unplayable with such a lag anyway.

  Client code: pkt_size = 8 + 2 + X * 8 (= 9810 for X = 35*35)
  Server code: pkt_size = 8 + 1 + X * (1 + 4 * (1 + 8)) (= 9074 for X = 7 * 35)

Fixes: #84