### PR TITLE
Fix nonrecording longtics

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -718,7 +718,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   cmd->forwardmove += fudgef((signed char)forward);
   cmd->sidemove += side;
 
-  if (!longtics)
+  if ((demorecording && !longtics) || shorttics)
   {
 	// Chocolate Doom Mouse Behaviour
 	// Don't discard mouse delta even if value is too small to


### PR DESCRIPTION
@fabiangreffrath @elim2g 
I think the issue is that "longtics" isn't set when not recording a demo, so the check there wasn't working as expected.

I've changed this to spell out the logic:
"recording a demo and not using longtics" or "specifically using shorttics"

I tested recording a demo with and without longtics on as well as regular play with and without shorttics and it seems to work.