### PR TITLE
Limit lump name length in "High lock on..." messages

### DIFF
--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -883,7 +883,7 @@ const rpatch_t *R_CachePatchNum(int id) {
 
 #ifdef SIMPLECHECKS
   if (!((patches[id].locks+1) & 0xf))
-    lprintf(LO_DEBUG, "R_CachePatchNum: High lock on %8s (%d)\n", 
+    lprintf(LO_DEBUG, "R_CachePatchNum: High lock on %.8s (%d)\n",
 	    lumpinfo[id].name, patches[id].locks);
 #endif
 
@@ -932,7 +932,7 @@ const rpatch_t *R_CacheTextureCompositePatchNum(int id) {
 
 #ifdef SIMPLECHECKS
   if (!((texture_composites[id].locks+1) & 0xf))
-    lprintf(LO_DEBUG, "R_CacheTextureCompositePatchNum: High lock on %8s (%d)\n", 
+    lprintf(LO_DEBUG, "R_CacheTextureCompositePatchNum: High lock on %.8s (%d)\n",
 	    textures[id]->name, texture_composites[id].locks);
 #endif
 

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -129,7 +129,7 @@ const void *W_CacheLumpNum(int lump)
 
 #ifdef SIMPLECHECKS
   if (!((cachelump[lump].locks+1) & 0xf))
-    lprintf(LO_DEBUG, "W_CacheLumpNum: High lock on %8s (%d)\n",
+    lprintf(LO_DEBUG, "W_CacheLumpNum: High lock on %.8s (%d)\n",
 	    lumpinfo[lump].name, cachelump[lump].locks);
 #endif
 

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -319,7 +319,7 @@ const void* W_LockLumpNum(int lump)
 
 #ifdef SIMPLECHECKS
   if (!((cachelump[lump].locks+1) & 0xf))
-    lprintf(LO_DEBUG, "W_CacheLumpNum: High lock on %8s (%d)\n",
+    lprintf(LO_DEBUG, "W_CacheLumpNum: High lock on %.8s (%d)\n",
       lumpinfo[lump].name, cachelump[lump].locks);
 #endif
 


### PR DESCRIPTION
Before (sometimes):
W_CacheLumpNum: High lock on DSITEMUPHEAD (15)
W_CacheLumpNum: High lock on DSSHOTGNSPOS�$ (15)
W_CacheLumpNum: High lock on DSSHOTGNSPOS�$ (31)`
W_CacheLumpNum: High lock on DSSHOTGNSPOS�$ (47)
W_CacheLumpNum: High lock on DSPOSACTSKEL* (15)
W_CacheLumpNum: High lock on DSPOPAINHEAD�! (15)

After:
W_CacheLumpNum: High lock on DSITEMUP (15)
W_CacheLumpNum: High lock on DSSHOTGN (15)
W_CacheLumpNum: High lock on DSSHOTGN (31)
W_CacheLumpNum: High lock on DSSHOTGN (47)
W_CacheLumpNum: High lock on DSPOSACT (15)
W_CacheLumpNum: High lock on DSPOPAIN (15)