### PR TITLE
Remove the WAD_INSTALL_PATH option

### DIFF
--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -362,5 +362,4 @@ add_custom_command(
     DEPENDS rdatawad ${WAD_SRC}
 )
 add_custom_target(prboomwad DEPENDS ${WAD_DATA_PATH})
-set(WAD_INSTALL_PATH ${DOOMWADDIR} CACHE PATH "Path to install prboom-plus.wad")
-install(FILES ${WAD_DATA_PATH} DESTINATION ${WAD_INSTALL_PATH} COMPONENT "PrBoom-Plus internal WAD")
+install(FILES ${WAD_DATA_PATH} DESTINATION ${DOOMWADDIR} COMPONENT "PrBoom-Plus internal WAD")


### PR DESCRIPTION
The engine currently lacks the relevant code for WAD_INSTALL_PATH to be
useful.