### PR TITLE
Track demo joins

### DIFF
--- a/prboom2/src/d_event.h
+++ b/prboom2/src/d_event.h
@@ -114,6 +114,8 @@ BT_WEAPONMASK_OLD   = (8+16+32),//e6y
   BTS_SAVEMASK    = (4+8+16),
   BTS_SAVESHIFT   = 2,
 
+  // Demo joined.
+  BT_JOIN = 64
 } buttoncode_t;
 
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -4065,6 +4065,10 @@ void G_ReadDemoContinueTiccmd (ticcmd_t* cmd)
   {
     demo_continue_p = NULL;
     democontinue = false;
+    // Sometimes this bit is not available
+    if ((demo_compatibility && !prboom_comp[PC_ALLOW_SSG_DIRECT].state) ||
+      (cmd->buttons & BT_CHANGE) == 0)
+      cmd->buttons |= BT_JOIN;
   }
 }
 


### PR DESCRIPTION
This PR stores demo joins as a new special input in the 7th bit of the "buttons" byte. The goal here is to track where segments meet for posterity and to assist with automated demo analysis performed for DSDA.

While this bit was unused in the original lmp format, it is sometimes used as an extra bit for weapon swap extensions (8 = chainsaw, 9 = ssg). This is the case for certain old versions of prboom+ (now achieved with the `-emulate` parameter or a specific flag) and for newer compatibility levels (boom, mbf, etc). In either of those contexts, and when a weapon swap is triggered, this bit must be left alone.

While this limitation is unfortunate, it's satisfactory for us to cover the cases we can, and there's only so much you can do without breaking compatibility entirely.

FYI @fabiangreffrath 