### PR TITLE
UMAPINFO: fix some episode transition issues

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1564,6 +1564,9 @@ void G_DoCompleted (void)
   if (automapmode & am_active)
     AM_Stop();
 
+  wminfo.nextep = wminfo.epsd = gameepisode -1;
+  wminfo.last = gamemap -1;
+
   wminfo.lastmapinfo = gamemapinfo;
   wminfo.nextmapinfo = NULL;
   if (gamemapinfo)
@@ -1581,6 +1584,12 @@ void G_DoCompleted (void)
 		  G_ValidateMapName(next, &wminfo.nextep, &wminfo.next);
 		  wminfo.nextep--;
 		  wminfo.next--;
+		  // episode change
+		  if (wminfo.nextep != wminfo.epsd)
+		  {
+		    for (i = 0; i < MAXPLAYERS; i++)
+		      players[i].didsecret = false;
+		  }
 		  wminfo.didsecret = players[consoleplayer].didsecret;
 		  wminfo.partime = gamemapinfo->partime;
 		  goto frommapinfo;	// skip past the default setup.
@@ -1612,8 +1621,6 @@ void G_DoCompleted (void)
   }
 
   wminfo.didsecret = players[consoleplayer].didsecret;
-  wminfo.nextep = wminfo.epsd = gameepisode -1;
-  wminfo.last = gamemap -1;
 
   // wminfo.next is 0 biased, unlike gamemap
   if (gamemode == commercial)

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -421,7 +421,7 @@ static void WI_slamBackground(void)
   else if (gamemode == commercial || (gamemode == retail && wbs->epsd == 3))
     strcpy(name, "INTERPIC");
   else
-    sprintf(name, "WIMAP%d", state == StatCount? wbs->epsd : wbs->nextep);
+    sprintf(name, "WIMAP%d", wbs->epsd);
 
   // background
   V_DrawNamePatch(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
@@ -966,6 +966,16 @@ void WI_initShowNextLoc(void)
 			return;
 		}
 		state = ShowNextLoc;
+
+		// episode change
+		if (wbs->epsd != wbs->nextep)
+		{
+			void WI_loadData(void);
+
+			wbs->epsd = wbs->nextep;
+			wbs->last = wbs->next - 1;
+			WI_loadData();
+		}
 	}
 	else if ((gamemode != commercial) && (gamemap == 8)) {
 		G_WorldDone();


### PR DESCRIPTION
* Fix wminfo.epsd and wminfo.last not being set for UMAPINFO defined
  maps. This would lead to the wrong episode background being drawn on
  the "Finished" intermission screen.
* Reset the didsecret property for all players when switching
  episodes, so the blood splat will not be drawn on ExM9.
* Next episode becomes current episode when switching from the
  "Finished" to the "Entering" intermission screen, so the correct
  background, animations, blood splat and "You are here" pointers are
  used.

Fixes: #98, thanks @UnluckySpade7.