### PR TITLE
Add "Dropped Item" support

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1036,7 +1036,7 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof deh_blocks/sizeof*deh_blocks)  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 24 // number of ints in the mobjinfo_t structure (!)
+#define DEH_MOBJINFOMAX 25 // number of ints in the mobjinfo_t structure (!)
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1100,7 +1100,8 @@ static const char *deh_mobjinfo[DEH_MOBJINFOMAX] =
   "Action sound",        // .activesound
   "Bits",                // .flags
   "Bits2",               // .flags
-  "Respawn frame"        // .raisestate
+  "Respawn frame",       // .raisestate
+  "Dropped item",        // .droppeditem
 };
 
 // Strings that are used to indicate flags ("Bits" in mobjinfo)
@@ -1427,6 +1428,27 @@ void D_BuildBEXTables(void)
    for(i = 1; i < NUMSFX; i++)
       deh_soundnames[i] = strdup(S_sfx[i].name);
    deh_soundnames[0] = deh_soundnames[NUMSFX] = NULL;
+
+  // ferk: initialize Thing extra properties (keeping vanilla props in info.c)
+  for (i = 0; i < NUMMOBJTYPES; i++)
+  {
+    // mobj id for item dropped on death
+    switch (i)
+    {
+      case MT_WOLFSS:
+      case MT_POSSESSED:
+      mobjinfo[i].droppeditem = MT_CLIP;
+      break;
+      case MT_SHOTGUY:
+      mobjinfo[i].droppeditem = MT_SHOTGUN;
+      break;
+      case MT_CHAINGUY:
+      mobjinfo[i].droppeditem = MT_CHAINGUN;
+      break;
+      default:
+      mobjinfo[i].droppeditem = MT_NULL;
+    }
+  }
 }
 
 int deh_maxhealth;
@@ -1828,6 +1850,7 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint_64_t value) {
         return;
       }
       break;
+    case 24: mi->droppeditem = (int)(value-1); return; // make it base zero (deh is 1-based)
     default: return;
   }
 }

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -1300,6 +1300,7 @@ extern const char *sprnames[]; /* 1/17/98 killough - CPhipps - const */
  */
 
 typedef enum {
+  MT_NULL = -1, // ferk: null/invalid mobj (zero is reserved for MT_PLAYER)
   MT_PLAYER,
   MT_POSSESSED,
   MT_SHOTGUY,
@@ -1541,6 +1542,7 @@ typedef struct
   int raisestate;   /* The first state for an Archvile or respawn
            resurrection.  Zero means it won't come
            back to life. */
+  mobjtype_t droppeditem; /* ferk: Mobj to drop after death */
 } mobjinfo_t;
 
 /* See p_mobj_h for addition more technical info */

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -805,24 +805,10 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   // This determines the kind of object spawned
   // during the death frame of a thing.
 
-  switch (target->type)
-    {
-    case MT_WOLFSS:
-    case MT_POSSESSED:
-      item = MT_CLIP;
-      break;
-
-    case MT_SHOTGUY:
-      item = MT_SHOTGUN;
-      break;
-
-    case MT_CHAINGUY:
-      item = MT_CHAINGUN;
-      break;
-
-    default:
-      return;
-    }
+  if (target->info->droppeditem != MT_NULL)
+  {
+    item = target->info->droppeditem;
+  }
 
   mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, item);
   mo->flags |= MF_DROPPED;    // special versions of items


### PR DESCRIPTION
Support the same dehacked Thing field as Doom Retro: https://github.com/bradharding/doomretro/commit/096f5ef09556dfa1cc5f0ab72d7d57f9c8e37010

"Dropped item" will allow to specify the Thing Id to be spawned after the Thing dies.

This was briefly discussed in Doomworld, regarding the extension of dehacked:
  https://www.doomworld.com/forum/topic/115638-dehextra-discussion-split-from-pr-umapinfo-thread/?tab=comments#comment-2155933