### PR TITLE
Fix a DeHackEd string replacements with length of exactly four.

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -2681,8 +2681,8 @@ static void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
           ++i;  // next array element
         }
     }
-  else
-    if (fromlen < 7 && tolen < 7)  // lengths of music and sfx are 6 or shorter
+
+    if (!found && fromlen < 7 && tolen < 7)  // lengths of music and sfx are 6 or shorter
       {
         usedlen = (fromlen < tolen) ? fromlen : tolen;
         if (fromlen != tolen)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4054,7 +4054,15 @@ void M_InitExtendedHelp(void)
     i = W_CheckNumForName(namebfr);
     if (i == -1) {
       if (extended_help_count) {
-        /* Update consolidated help menu */
+        /* The Extended Help menu is accessed using the
+         * Help hotkey (F1) or the "Read This!" menu item.
+         *
+         * If Extended Help screens are present, use the
+         * Extended Help routine when either the F1 Help Menu
+         * or the "Read This!" menu items are accessed.
+         *
+         * See also: https://www.doomworld.com/forum/topic/111465-boom-extended-help-screens-an-undocumented-feature/
+         */
           HelpMenu[0].routine = M_ExtHelp;
         if (gamemode == commercial) {
           ExtHelpDef.prevMenu  = &ReadDef1; /* previous menu */

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4054,13 +4054,15 @@ void M_InitExtendedHelp(void)
     i = W_CheckNumForName(namebfr);
     if (i == -1) {
       if (extended_help_count) {
+        /* Update consolidated help menu */
+          HelpMenu[0].routine = M_ExtHelp;
         if (gamemode == commercial) {
           ExtHelpDef.prevMenu  = &ReadDef1; /* previous menu */
           ReadMenu1[0].routine = M_ExtHelp;
-  } else {
+        } else {
           ExtHelpDef.prevMenu  = &ReadDef2; /* previous menu */
           ReadMenu2[0].routine = M_ExtHelp;
-  }
+        }
       }
       return;
     }


### PR DESCRIPTION
This PR proposes a fix for DeHackEd string replacements with a length of exactly four. The issue was first reported by esselfortium in [this thread](https://www.doomworld.com/forum/topic/115788-deh-music-string-replacement-buggy-in-boom-based-ports/).

The bug occurs when a string replacement has a from and to length of exactly four. The original code assumes such a condition implies a sprite and does not check if a matching music or sound string exists.

This fix would also check for music and sound replacements if a matching sprite is not found, as with any string replacement.