### PR TITLE
Fix a DeHackEd string replacements with length of exactly four.

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -2681,8 +2681,8 @@ static void deh_procText(DEHFILE *fpin, FILE* fpout, char *line)
           ++i;  // next array element
         }
     }
-  else
-    if (fromlen < 7 && tolen < 7)  // lengths of music and sfx are 6 or shorter
+
+    if (!found && fromlen < 7 && tolen < 7)  // lengths of music and sfx are 6 or shorter
       {
         usedlen = (fromlen < tolen) ? fromlen : tolen;
         if (fromlen != tolen)


### PR DESCRIPTION
This PR proposes a fix for DeHackEd string replacements with a length of exactly four. The issue was first reported by esselfortium in this thread.

The bug occurs when a string replacement has a from and to length of exactly four. The original code assumes such a condition implies a sprite and does not check if a matching music or sound string exists.

This fix would also check for music and sound replacements if a matching sprite is not found, as with any string replacement.