### PR TITLE
Fix dropped items error

### DIFF
--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -809,6 +809,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   {
     item = target->info->droppeditem;
   }
+  else return;
 
   mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, item);
   mo->flags |= MF_DROPPED;    // special versions of items


### PR DESCRIPTION
As indicated by @fabiangreffrath in https://github.com/coelckers/prboom-plus/commit/b201a986345a091b11aae4029d2dfb5fd7574fa9#r40873799, there was a mistake in the droppeditems condition.
When it was refactored to use the same pattern as crispy the `return` was missing by mistake.
I'm sorry, this can cause a segfault.