### PR TITLE
Update endpic checks to also check for '-' (blank) endpic.

### DIFF
--- a/prboom2/src/f_finale2.c
+++ b/prboom2/src/f_finale2.c
@@ -124,7 +124,7 @@ void FMI_Ticker(void)
 			(midstage && acceleratestage)) {
 
 		next_level:
-			if (gamemapinfo->endpic[0])
+			if (gamemapinfo->endpic[0] && (strcmp(gamemapinfo->endpic, "-") != 0))
 			{
 				if (!stricmp(gamemapinfo->endpic, "$CAST"))
 				{
@@ -157,7 +157,7 @@ void FMI_Ticker(void)
 //
 void FMI_Drawer(void)
 {
-	if (!finalestage || !gamemapinfo->endpic[0])
+	if (!finalestage || !gamemapinfo->endpic[0] || (strcmp(gamemapinfo->endpic, "-") == 0))
 	{
 		F_TextWrite();
 	}

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1572,7 +1572,7 @@ void G_DoCompleted (void)
   if (gamemapinfo)
   {
 	  const char *next = "";
-	  if (gamemapinfo->endpic[0] && gamemapinfo->nointermission)
+	  if (gamemapinfo->endpic[0] && (strcmp(gamemapinfo->endpic, "-") != 0) && gamemapinfo->nointermission)
 	  {
 		  gameaction = ga_victory;
 		  return;
@@ -1775,7 +1775,7 @@ void G_WorldDone (void)
 
 		  return;
 	  }
-	  else if (gamemapinfo->endpic[0])
+	  else if (gamemapinfo->endpic[0] && (strcmp(gamemapinfo->endpic, "-") != 0))
 	  {
 		  // game ends without a status screen.
 		  gameaction = ga_victory;


### PR DESCRIPTION
A proposed fix for #118.

The UMAPINFO scanner will insert a '-' character to indicate a blank endpic. However, the in-game checks for endpic only check for a null endpic, which would happen if UMAPINFO is loaded but no endpic or endgame entries are found and the map is not normally an endgame map.

This PR proposes a fix to this by modifying gameplay checks to look for a '-' character endpic. This would occur if endgame was set to false, or a traditional cast call or "bunny" ending was falsified.