### PR TITLE
Fix segfault when handling -viewangle parameter when it is the last parameter

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1597,7 +1597,7 @@ static void D_DoomMainSetup(void)
 
   //proff 11/22/98: Added setting of viewangleoffset
   p = M_CheckParm("-viewangle");
-  if (p)
+  if (p && p < myargc-1)
   {
     viewangleoffset = atoi(myargv[p+1]);
     viewangleoffset = viewangleoffset<0 ? 0 : (viewangleoffset>7 ? 7 : viewangleoffset);


### PR DESCRIPTION
I found a segfault in the parameter handling code. A small code change should do it.

By the way, this is my first contribution; please be nice :) and let me know if I'm missing anything.