### PR TITLE
Do not reset next levels if endscreen is disabled in UMAPINFO

### DIFF
--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -520,7 +520,7 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 		ParseMapEntry(scanner, &parsed);
 
 		// Set default level progression here to simplify the checks elsewhere. Doing this lets us skip all normal code for this if nothing has been defined.
-		if (parsed.endpic[0])
+		if (parsed.endpic[0] && parsed.endpic[0] != '-')
 		{
 			parsed.nextmap[0] = parsed.nextsecret[0] = 0;
 			if (parsed.endpic[0] == '!') parsed.endpic[0] = 0;

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -520,7 +520,7 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 		ParseMapEntry(scanner, &parsed);
 
 		// Set default level progression here to simplify the checks elsewhere. Doing this lets us skip all normal code for this if nothing has been defined.
-		if (parsed.endpic[0] && parsed.endpic[0] != '-')
+		if (parsed.endpic[0] && (strcmp(parsed.endpic, "-") != 0))
 		{
 			parsed.nextmap[0] = parsed.nextsecret[0] = 0;
 			if (parsed.endpic[0] == '!') parsed.endpic[0] = 0;


### PR DESCRIPTION
If the `endpic` property is present in an UMAPINFO lump, the `next` and `nextsecret` properties are *zero'ed*, even if the end screen is disabled by `endpic = "-"`. This may mess up intended level progression. Building with this fix solves the problem.

I didn't include an exception for "!" since i don't fully understand the behaviour of `endgame`.
In this case, `next` and `nextsecret` are still *zero'ed*, but the game only ends when that's the default (like in MAP30).