### PR TITLE
Provide documentation installation support for older CMake

### DIFF
--- a/prboom2/doc/CMakeLists.txt
+++ b/prboom2/doc/CMakeLists.txt
@@ -19,6 +19,10 @@ set(MAN6_FILES
     prboom-plus-game-server.6
 )
 
-install(FILES ${DOC_FILES} TYPE DOC COMPONENT "Documentation")
+if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+	install(FILES ${DOC_FILES} DESTINATION "${CMAKE_INSTALL_DOCDIR}" COMPONENT "Documentation")
+else()
+	install(FILES ${DOC_FILES} TYPE DOC COMPONENT "Documentation")
+endif()
 install(FILES ${MAN5_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man5" COMPONENT "Manpages")
 install(FILES ${MAN6_FILES} DESTINATION "${CMAKE_INSTALL_MANDIR}/man6" COMPONENT "Manpages")


### PR DESCRIPTION
Support for the `TYPE` parameter of the CMake `install(FILES ...)`
command was added in the version 3.14.0 release of CMake. Older versions
should use the `DESTINATION` parameter as an alternative.

Bug: https://github.com/coelckers/prboom-plus/issues/125