### PR TITLE
- moved the secret notification to the "Miscellaneous" submenu inside "General"

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3198,11 +3198,11 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Game speed, percentage of normal", S_NUM|S_PRGWARN, m_null, G_X, G_Y+13*8, {"realtic_clock_rate"}},
   {"Default skill level",              S_CHOICE,        m_null, G_X, G_Y+14*8, {"default_skill"}, 0, 0, NULL, gen_skillstrings},
   {"Default compatibility level",      S_CHOICE,        m_null, G_X, G_Y+15*8, {"default_compatibility_level"}, 0, 0, NULL, &gen_compstrings[1]},
-  {"Show Secret Notifications",        S_YESNO,         m_null, ADVHUD_X, SB_Y+ 2*8, {"hudadd_secretarea"}},
-  {"Show ENDOOM screen",               S_YESNO,         m_null, G_X, G_Y+16*8, {"showendoom"}},
-  {"Fullscreen menu background",       S_YESNO, m_null, G_X, G_Y + 17*8, {"menu_background"}},
+  {"Show Secret Notifications",        S_YESNO,         m_null, G_X, G_Y+16*8, {"hudadd_secretarea"}},
+  {"Show ENDOOM screen",               S_YESNO,         m_null, G_X, G_Y+17*8, {"showendoom"}},
+  {"Fullscreen menu background",       S_YESNO, m_null, G_X, G_Y + 18*8, {"menu_background"}},
 #ifdef USE_WINDOWS_LAUNCHER
-  {"Use In-Game Launcher",             S_CHOICE,        m_null, G_X, G_Y+ 18*8, {"launcher_enable"}, 0, 0, NULL, launcher_enable_states},
+  {"Use In-Game Launcher",             S_CHOICE,        m_null, G_X, G_Y+ 19*8, {"launcher_enable"}, 0, 0, NULL, launcher_enable_states},
 #endif
 
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2720,7 +2720,6 @@ setup_menu_t stat_settings1[] =  // Status Bar and HUD Settings screen
 setup_menu_t stat_settings2[] =
 {
   {"ADVANCED HUD SETTINGS"       ,S_SKIP|S_TITLE,m_null,ADVHUD_X,SB_Y+1*8},
-  {"REPORT REVEALED SECRETS"     ,S_YESNO     ,m_null,ADVHUD_X,SB_Y+ 2*8, {"hudadd_secretarea"}},
   {"SMART TOTALS"                ,S_YESNO     ,m_null,ADVHUD_X,SB_Y+ 3*8, {"hudadd_smarttotals"}},
   {"SHOW GAMESPEED"              ,S_YESNO     ,m_null,ADVHUD_X,SB_Y+ 4*8, {"hudadd_gamespeed"}},
   {"SHOW LEVELTIME"              ,S_YESNO     ,m_null,ADVHUD_X,SB_Y+ 5*8, {"hudadd_leveltime"}},
@@ -3199,6 +3198,7 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Game speed, percentage of normal", S_NUM|S_PRGWARN, m_null, G_X, G_Y+13*8, {"realtic_clock_rate"}},
   {"Default skill level",              S_CHOICE,        m_null, G_X, G_Y+14*8, {"default_skill"}, 0, 0, NULL, gen_skillstrings},
   {"Default compatibility level",      S_CHOICE,        m_null, G_X, G_Y+15*8, {"default_compatibility_level"}, 0, 0, NULL, &gen_compstrings[1]},
+  {"Show Secret Notifications",        S_YESNO,         m_null, ADVHUD_X, SB_Y+ 2*8, {"hudadd_secretarea"}},
   {"Show ENDOOM screen",               S_YESNO,         m_null, G_X, G_Y+16*8, {"showendoom"}},
   {"Fullscreen menu background",       S_YESNO, m_null, G_X, G_Y + 17*8, {"menu_background"}},
 #ifdef USE_WINDOWS_LAUNCHER


### PR DESCRIPTION
Mainly to improve visibility and awareness, I've seen people not knowing this even exits some time ago, including yours truly.

Rightfully so, its original location inside "Setup" (really, Setup out of all things?) is not the best one could come up with, admittedly. I think it fits much better here.

I've also renamed it to better fit in with the rest of the settings. I initially got it half-right though, hence two commits - it was still trying to display like the settings from its original location, because I missed the obvious, heh.

Now it's good, and of course it's tested. It works as it should.