### PR TITLE
Update INSTALL

### DIFF
--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -29,7 +29,7 @@ Basic Installation (ZIP, tarball, Git)
      Run `cmake .. -DCMAKE_BUILD_TYPE=Release` from this folder, or 
      `cmake .. -DCMAKE_BUILD_TYPE=Debug` for a debug build. (This gives
      slightly lower performance, but more details in the event of 
-     issues)
+     issues).
      
      This should end with the message "Build files have been written to: [folderpath]".
 
@@ -59,7 +59,7 @@ Basic Installation (ZIP, tarball, Git)
      can access the IWAD file.
      
      You may also aquire FreeDoom from https://freedoom.github.io/ which is a 
-     free replacement to the iD Doom iWADs
+     free replacement to the iD Doom iWADs.
 
   6. You can remove the program binaries and object files from the
      source directory by typing `make clean`.  To also remove the
@@ -73,31 +73,6 @@ Basic Installation (ZIP, tarball, Git)
   7. PrBoom is now ready for use. If /usr/local/games is in your path,
      you can just run prboom; otherwise give the full path.
 
-     
-     
-Installation From SVN
-=====================
-
-If you intend to compile PrBoom from a source tar file, such as
-prboom-plus-2.5.1.5.tar.gz, as opposed to SVN, skip to the "Basic Installation"
-section.
-
-  1. Extract the PrBoom distribution from SVN:
-        svn co https://svn.prboom.org/repos/branches/prboom-plus-24/prboom2
-
-  2. 'cd' to the directory containing the PrBoom distribution (the directory
-     this file is in):
-        cd prboom2
-
-  3. Run the 'bootstrap' script in order to create the 'configure' script.
-        ./bootstrap
-     If you get this error:
-        aclocal: configure.ac: 153: macro `AM_PATH_SDL' not found in library
-     Then you have to locate sdl.m4 and copy it to ./autotools/sdl.m4 in your
-     prboom directory.
-
-  4. If the 'configure' script was created by step 3 then proceed to the
-     "Basic Installation" section.
 
      
 Building an RPM

--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -1,3 +1,77 @@
+Basic Installation (ZIP, tarball, Git)
+==================
+
+  1. To compile PrBoom-Plus, you need at least SDL2. To enable various
+     extensions and optional features, the following are required:
+     - SDL2_net (for network play)
+     - SDL2_image (for high-res textures in OpenGL, and PNG screenshots)
+     - PCRE (for demo filename pattern matching)
+     - for music support, some or all of
+       * SDL2_mixer (midi, timidity)
+       * Fluidsynth (midi)
+       * Portmidi (midi)
+       * MAD (mp3)
+       * DUMB (various tracker-style formats)
+       * vorbisfile (ogg)
+     On a typical Debian or Ubuntu system this may be sufficient:
+       apt-get install libsdl2-dev libsdl2-net-dev libsdl2-image-dev \
+         libpcre3-dev libsdl2-mixer-dev libfluidsynth-dev \
+         libportmidi-dev libmad0-dev libdumb1-dev libvorbis-dev
+         
+    You will also need `cmake` and `make` if you haven't already got them.
+         
+  2. `cd' to the directory containing the PrBoom distribution (the directory
+     this file is in, prboom2).
+
+     Run `cmake .` from this folder
+     
+     This should end with the message "Build files have been written to: [folderpath]"
+
+  3. Type `make' to compile PrBoom. This may take some time; while it's
+     compiling I suggest you read the README, or maybe go and look for some
+     good doom levels to play when it's finished :-).
+
+     This should work on all Linux systems, but systems that have a make
+     utility other than GNU make may have problems. E.g. you might need to
+     install GNU make, and then use it instead of make for these
+     instructions. I have tested BSD pmake and it works fine.
+
+  4. Type `make install-strip' as root, to install the programs, data files
+     and man pages for PrBoom. If you don't have root access on the machine,
+     you should ask the syadmin to do this and the next step for you.
+     
+     If you want to install manually then you must put the `prboom-plus.wad` 
+     in /usr/local/share/games/doom/ (or symlink it from there).
+
+  5. Copy your Doom, Doom 2, Ultimate Doom or Final Doom IWAD (doom.wad or
+     doom2.wad) to /usr/local/share/games/doom/ (or symlink it from there).
+     Or if you don't have any of those, use the shareware IWAD, which you can
+     get from http://www.doomworld.com/ or http://www.idsoftware.com/.
+
+     If you have a system with many users, you should read the license for
+     your version of Doom, and make sure only those users allowed to use it
+     can access the IWAD file.
+     
+     You can also aquire FreeDoom from https://freedoom.github.io/ which is a 
+     free replacement to the iD Doom iWADs (although if you intend to upload demos to DSDA this iWAD isn't sufficient) 
+
+  6. You can remove the program binaries and object files from the
+     source directory by typing `make clean'.  To also remove the
+     files that `configure' created (so you can compile the package for
+     a different kind of computer), type `make distclean'.  There is
+     also a `make maintainer-clean' target, but that is intended mainly
+     for the package's developers.  If you use it, you may have to get
+     all sorts of other programs in order to regenerate files that came
+     with the distribution.
+
+  7. PrBoom is now ready for use. If /usr/local/games is in your path,
+     you can just run prboom; otherwise give the full path.
+
+     See the README file for information about getting the Timidity
+     patches needed for music support, and more.
+
+     
+     
 Installation From SVN
 =====================
 
@@ -22,74 +96,7 @@ section.
   4. If the 'configure' script was created by step 3 then proceed to the
      "Basic Installation" section.
 
-Basic Installation
-==================
-
-  1. To compile PrBoom-Plus, you need at least SDL2. To enable various
-     extensions and optional features, the following are required:
-     - SDL2_net (for network play)
-     - SDL2_image (for high-res textures in OpenGL, and PNG screenshots)
-     - PCRE (for demo filename pattern matching)
-     - for music support, some or all of
-       * SDL2_mixer (midi, timidity)
-       * Fluidsynth (midi)
-       * Portmidi (midi)
-       * MAD (mp3)
-       * DUMB (various tracker-style formats)
-       * vorbisfile (ogg)
-     On a typical Debian or Ubuntu system this may be sufficient:
-       apt-get install libsdl2-dev libsdl2-net-dev libsdl2-image-dev \
-         libpcre3-dev libsdl2-mixer-dev libfluidsynth-dev \
-         libportmidi-dev libmad0-dev libdumb1-dev libvorbis-dev
-
-  2. `cd' to the directory containing the PrBoom distribution (the directory
-     this file is in).
-
-     Type `./configure' to configure PrBoom for your system.  If you're
-     using `csh' on an old version of System V, you might need to type
-     `sh ./configure' instead to prevent `csh' from trying to execute
-     `configure' itself.
-
-     Running `configure' takes awhile.  While running, it prints some
-     messages telling which features it is checking for.
-
-  3. Type `make' to compile PrBoom. This may take some time; while it's
-     compiling I suggest you read the README, or maybe go and look for some
-     good doom levels to play when it's finished :-).
-
-     This should work on all Linux systems, but systems that have a make
-     utility other than GNU make may have problems. E.g. you might need to
-     install GNU make, and then use it instead of make for these
-     instructions. I have tested BSD pmake and it works fine.
-
-  4. Type `make install-strip' as root, to install the programs, data files
-     and man pages for PrBoom. If you don't have root access on the machine,
-     you should ask the syadmin to do this and the next step for you.
-
-  5. Copy your Doom, Doom 2, Ultimate Doom or Final Doom IWAD (doom.wad or
-     doom2.wad) to /usr/local/share/games/doom/ (or symlink it from there).
-     Or if you don't have any of those, use the shareware IWAD, which you can
-     get from http://www.doomworld.com/ or http://www.idsoftware.com/.
-
-     If you have a system with many users, you should read the license for
-     your version of Doom, and make sure only those users allowed to use it
-     can access the IWAD file.
-
-  6. You can remove the program binaries and object files from the
-     source directory by typing `make clean'.  To also remove the
-     files that `configure' created (so you can compile the package for
-     a different kind of computer), type `make distclean'.  There is
-     also a `make maintainer-clean' target, but that is intended mainly
-     for the package's developers.  If you use it, you may have to get
-     all sorts of other programs in order to regenerate files that came
-     with the distribution.
-
-  7. PrBoom is now ready for use. If /usr/local/games is in your path,
-     you can just run prboom; otherwise give the full path.
-
-     See the README file for information about getting the Timidity
-     patches needed for music support, and more.
-
+     
 Building an RPM
 ===============
 

--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -22,9 +22,12 @@ Basic Installation (ZIP, tarball, Git)
          
   2. `cd' to the directory containing the PrBoom distribution (the directory
      this file is in, prboom2).
-
-     Run `cmake . -DCMAKE_BUILD_TYPE=Release` from this folder, or 
-     `cmake . -DCMAKE_BUILD_TYPE=Debug` for a debug build. (This gives
+     
+     Create a new `build` folder and `cd` into it. 
+     `mkdir build && cd build`
+     
+     Run `cmake .. -DCMAKE_BUILD_TYPE=Release` from this folder, or 
+     `cmake .. -DCMAKE_BUILD_TYPE=Debug` for a debug build. (This gives
      slightly lower performance, but more details in the event of 
      issues)
      

--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -23,7 +23,10 @@ Basic Installation (ZIP, tarball, Git)
   2. `cd' to the directory containing the PrBoom distribution (the directory
      this file is in, prboom2).
 
-     Run `cmake .` from this folder
+     Run `cmake . -DCMAKE_BUILD_TYPE=Release` from this folder
+     (You should remove the -DCMAKE... if you wish to get a debug build
+     for better info about crashes and such if using experimental code.
+     This does reduce performance)
      
      This should end with the message "Build files have been written to: [folderpath]"
 
@@ -53,7 +56,7 @@ Basic Installation (ZIP, tarball, Git)
      can access the IWAD file.
      
      You can also aquire FreeDoom from https://freedoom.github.io/ which is a 
-     free replacement to the iD Doom iWADs (although if you intend to upload demos to DSDA this iWAD isn't sufficient) 
+     free replacement to the iD Doom iWADs
 
   6. You can remove the program binaries and object files from the
      source directory by typing `make clean'.  To also remove the

--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -23,14 +23,14 @@ Basic Installation (ZIP, tarball, Git)
   2. `cd' to the directory containing the PrBoom distribution (the directory
      this file is in, prboom2).
 
-     Run `cmake . -DCMAKE_BUILD_TYPE=Release` from this folder
-     (You should remove the -DCMAKE... if you wish to get a debug build
-     for better info about crashes and such if using experimental code.
-     This does reduce performance)
+     Run `cmake . -DCMAKE_BUILD_TYPE=Release` from this folder, or 
+     `cmake . -DCMAKE_BUILD_TYPE=Debug` for a debug build. (This gives
+     slightly lower performance, but more details in the event of 
+     issues)
      
-     This should end with the message "Build files have been written to: [folderpath]"
+     This should end with the message "Build files have been written to: [folderpath]".
 
-  3. Type `make' to compile PrBoom. This may take some time; while it's
+  3. Type `make` to compile PrBoom. This may take some time; while it's
      compiling I suggest you read the README, or maybe go and look for some
      good doom levels to play when it's finished :-).
 
@@ -43,7 +43,7 @@ Basic Installation (ZIP, tarball, Git)
      and man pages for PrBoom. If you don't have root access on the machine,
      you should ask the syadmin to do this and the next step for you.
      
-     If you want to install manually then you must put the `prboom-plus.wad` 
+     If you want to install manually then you should put the `prboom-plus.wad` 
      in /usr/local/share/games/doom/ (or symlink it from there).
 
   5. Copy your Doom, Doom 2, Ultimate Doom or Final Doom IWAD (doom.wad or
@@ -55,11 +55,11 @@ Basic Installation (ZIP, tarball, Git)
      your version of Doom, and make sure only those users allowed to use it
      can access the IWAD file.
      
-     You can also aquire FreeDoom from https://freedoom.github.io/ which is a 
+     You may also aquire FreeDoom from https://freedoom.github.io/ which is a 
      free replacement to the iD Doom iWADs
 
   6. You can remove the program binaries and object files from the
-     source directory by typing `make clean'.  To also remove the
+     source directory by typing `make clean`.  To also remove the
      files that `configure' created (so you can compile the package for
      a different kind of computer), type `make distclean'.  There is
      also a `make maintainer-clean' target, but that is intended mainly
@@ -69,9 +69,6 @@ Basic Installation (ZIP, tarball, Git)
 
   7. PrBoom is now ready for use. If /usr/local/games is in your path,
      you can just run prboom; otherwise give the full path.
-
-     See the README file for information about getting the Timidity
-     patches needed for music support, and more.
 
      
      


### PR DESCRIPTION
I have changed the "Basic Installation" to the top as the SVN isn't the main place I believe people get the code from, and changed the Basic Install guide to have the correct instructions (with ./configure missing and instead being cmake .) and added some basic instructions for manual installation (copying the files instead of using make install) as well as a link to FreeDoom as a potential alternative if the user doesn't have iD's Doom. 

The required libraries are correct on Ubuntu and Debian systems (tested on Ubuntu 20.04) and with minor changes to packages downloaded, these instructions work on Void Linux too.