### PR TITLE
fix psprite positioning problem for real

### DIFF
--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1000,7 +1000,7 @@ static void R_DrawPSprite (pspdef_t *psp)
   vis = &avis;
   vis->mobjflags = MF_PLAYERSPRITE;
    // killough 12/98: fix psprite positioning problem
-  vis->texturemid = (BASEYCENTER<<FRACBITS) /* +  FRACUNIT/2 */ -
+  vis->texturemid = (BASEYCENTER<<FRACBITS) + FRACUNIT/4 -
                     (psp_sy-topoffset);
 
   // Move the weapon down for 1280x1024.


### PR DESCRIPTION
The FRACUNIT/4 value comes from Crispy Doom. It's a compromise between
the weapon sprite floating in the air (FRACUNIT/2) and a line of
Tutti-Frutti printed on top (0).