### PR TITLE
support named complevels on the command line, e.g. "-complevel boom"

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2006,18 +2006,23 @@ unsigned int GetPackageVersion(void)
 
 // [FG] support named complevels on the command line, e.g. "-complevel boom",
 // names based on the args to Chocolate Doom's "-gameversion" parameter
+// and IWAD file names
 
 static int GetComplevel (const char *arg)
 {
   int i;
 
-  struct {
-    const int level;
+  const struct {
+    int level;
     const char *const name;
   } named_complevel[] = {
     {2, "1.9"},
+    {2, "doom2"},
     {3, "ultimate"},
+    {3, "udoom"},
     {4, "final"},
+    {4, "tnt"},
+    {4, "plutonia"},
     {9, "boom"},
     {11, "mbf"},
   };

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2031,7 +2031,7 @@ int G_GetNamedComplevel (const char *arg)
   // choose the complevel based on the IWAD
   if (!strcasecmp(arg, "vanilla"))
   {
-    if (gamemode == retail)
+    if (gamemode == retail || gamemission == chex)
       return 3;
     else if (gamemode == commercial && (gamemission == pack_plut || gamemission == pack_tnt))
       return 4;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2028,6 +2028,7 @@ int G_GetNamedComplevel (const char *arg)
     {11, "mbf"},
   };
 
+  // choose the complevel based on the IWAD
   if (!strcasecmp(arg, "vanilla"))
   {
     if (gamemode == retail)

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2008,7 +2008,7 @@ unsigned int GetPackageVersion(void)
 // names based on the args to Chocolate Doom's "-gameversion" parameter
 // and IWAD file names
 
-int GetComplevel (const char *arg)
+int G_GetNamedComplevel (const char *arg)
 {
   int i;
 
@@ -2019,6 +2019,7 @@ int GetComplevel (const char *arg)
     {2, "1.9"},
     {2, "doom2"},
     {3, "ultimate"},
+//  {3, "doom"}, // deemed too ambigious
     {3, "udoom"},
     {4, "final"},
     {4, "tnt"},
@@ -2026,6 +2027,16 @@ int GetComplevel (const char *arg)
     {9, "boom"},
     {11, "mbf"},
   };
+
+  if (!strcasecmp(arg, "vanilla"))
+  {
+    if (gamemode == retail)
+      return 3;
+    else if (gamemode == commercial && (gamemission == pack_plut || gamemission == pack_tnt))
+      return 4;
+    else
+      return 2;
+  }
 
   for (i = 0; i < sizeof(named_complevel)/sizeof(*named_complevel); i++)
   {
@@ -2683,7 +2694,7 @@ void G_ReloadDefaults(void)
   {
     int i = M_CheckParm("-complevel");
     if (i && (1+i) < myargc) {
-      int l = GetComplevel(myargv[i+1]);;
+      int l = G_GetNamedComplevel(myargv[i+1]);;
       if (l >= -1) compatibility_level = l;
     }
   }
@@ -3514,7 +3525,7 @@ static int G_GetOriginalDoomCompatLevel(int ver)
     int i = M_CheckParm("-complevel");
     if (i && (i+1 < myargc))
     {
-      lev = GetComplevel(myargv[i+1]);
+      lev = G_GetNamedComplevel(myargv[i+1]);
       if (lev>=0)
         return lev;
     }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2008,7 +2008,7 @@ unsigned int GetPackageVersion(void)
 // names based on the args to Chocolate Doom's "-gameversion" parameter
 // and IWAD file names
 
-static int GetComplevel (const char *arg)
+int GetComplevel (const char *arg)
 {
   int i;
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2004,6 +2004,35 @@ unsigned int GetPackageVersion(void)
   return PACKAGEVERSION;
 }
 
+// [FG] support named complevels on the command line, e.g. "-complevel boom",
+// names based on the args to Chocolate Doom's "-gameversion" parameter
+
+static int GetComplevel (const char *arg)
+{
+  int i;
+
+  struct {
+    const int level;
+    const char *const name;
+  } named_complevel[] = {
+    {2, "1.9"},
+    {3, "ultimate"},
+    {4, "final"},
+    {9, "boom"},
+    {11, "mbf"},
+  };
+
+  for (i = 0; i < sizeof(named_complevel)/sizeof(*named_complevel); i++)
+  {
+    if (!strcasecmp(arg, named_complevel[i].name))
+    {
+      return named_complevel[i].level;
+    }
+  }
+
+  return atoi(arg);
+}
+
 //==========================================================================
 //
 // RecalculateDrawnSubsectors
@@ -2649,7 +2678,7 @@ void G_ReloadDefaults(void)
   {
     int i = M_CheckParm("-complevel");
     if (i && (1+i) < myargc) {
-      int l = atoi(myargv[i+1]);;
+      int l = GetComplevel(myargv[i+1]);;
       if (l >= -1) compatibility_level = l;
     }
   }
@@ -3480,7 +3509,7 @@ static int G_GetOriginalDoomCompatLevel(int ver)
     int i = M_CheckParm("-complevel");
     if (i && (i+1 < myargc))
     {
-      lev = atoi(myargv[i+1]);
+      lev = GetComplevel(myargv[i+1]);
       if (lev>=0)
         return lev;
     }

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -573,9 +573,10 @@ static void R_DemoEx_GetParams(const byte *pwad_p, waddata_t *waddata)
       {
         int level;
         static char str[4];
-        extern int GetComplevel (const char *arg);
+        extern int G_GetNamedComplevel (const char *arg);
         M_AddParam("-complevel");
-        level = GetComplevel(params[p + 1]);
+        // [FG] only save numeric complevel values
+        level = G_GetNamedComplevel(params[p + 1]);
         snprintf(str, sizeof(str), "%d", level);
         M_AddParam(str);
       }

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -571,8 +571,13 @@ static void R_DemoEx_GetParams(const byte *pwad_p, waddata_t *waddata)
       p = M_CheckParmEx("-complevel", params, paramscount);
       if (p >= 0 && p < (int)paramscount - 1)
       {
+        int level;
+        static char str[4];
+        extern int GetComplevel (const char *arg);
         M_AddParam("-complevel");
-        M_AddParam(params[p + 1]);
+        level = GetComplevel(params[p + 1]);
+        snprintf(str, sizeof(str), "%d", level);
+        M_AddParam(str);
       }
     }
 


### PR DESCRIPTION
The names are based on the args to Chocolate Doom's "-gameversion"
parameter and are currently restricted to the most usual 5 complevels.