### PR TITLE
fix garbage lines at the top of weapon sprites

### DIFF
--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -806,6 +806,12 @@ void R_ExecuteSetViewSize (void)
   pspritexscale = (wide_centerx << FRACBITS) / 160;
   pspriteyscale = (((cheight*viewwidth)/SCREENWIDTH) << FRACBITS) / 200;
   pspriteiscale = FixedDiv (FRACUNIT, pspritexscale);
+  // [FG] make sure that the product of the weapon sprite scale factor
+  //      and its reciprocal is always at least FRACUNIT to
+  //      fix garbage lines at the top of weapon sprites
+  pspriteiyscale = FixedDiv (FRACUNIT, pspriteyscale);
+  while (FixedMul(pspriteiyscale, pspriteyscale) < FRACUNIT)
+    pspriteiyscale++;
 
   //e6y: added for GL
   pspritexscale_f = (float)wide_centerx/160.0f;

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -61,6 +61,7 @@ fixed_t pspriteiscale;
 // proff 11/06/98: Added for high-res
 fixed_t pspritexscale;
 fixed_t pspriteyscale;
+fixed_t pspriteiyscale;
 
 static const lighttable_t **spritelights;        // killough 1/25/98 made static
 
@@ -564,6 +565,8 @@ static void R_DrawVisSprite(vissprite_t *vis)
   // check to see if weapon is a vissprite
   if(vis->mobjflags & MF_PLAYERSPRITE)
   {
+    // [FG] fix garbage lines at the top of weapon sprites
+    dcvars.iscale = pspriteiyscale;
     dcvars.texturemid += FixedMul(((centery - viewheight/2)<<FRACBITS), dcvars.iscale);
     sprtopscreen += (viewheight/2 - centery)<<FRACBITS;
   }

--- a/prboom2/src/r_things.h
+++ b/prboom2/src/r_things.h
@@ -60,6 +60,7 @@ extern fixed_t pspriteiscale;
 /* proff 11/06/98: Added for high-res */
 extern fixed_t pspritexscale;
 extern fixed_t pspriteyscale;
+extern fixed_t pspriteiyscale;
 //e6y: added for GL
 extern float pspritexscale_f;
 extern float pspriteyscale_f;


### PR DESCRIPTION
by making sure that the product of the weapon sprite scale factor
and its reciprocal is always at least FRACUNIT. Fixes #95.