### PR TITLE
Fix odd strafe values

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -700,7 +700,15 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     forward += mousey;
   }
   if (strafe)
+  {
     side += mousex / movement_mousestrafedivisor; /* mead  Don't want to strafe as fast as turns.*/
+
+    // You can only produce even strafe values in vanilla doom
+    if (demo_compatibility)
+    {
+      side &= ~1;
+    }
+  }
   else
     cmd->angleturn -= mousex; /* mead now have enough dynamic range 2-10-00 */
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -702,12 +702,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   if (strafe)
   {
     side += mousex / movement_mousestrafedivisor; /* mead  Don't want to strafe as fast as turns.*/
-
-    // You can only produce even strafe values in vanilla doom
-    if (demo_compatibility)
-    {
-      side &= ~1;
-    }
+    side = (side / 2) * 2; // only even values are possible
   }
   else
     cmd->angleturn -= mousex; /* mead now have enough dynamic range 2-10-00 */


### PR DESCRIPTION
There's a major bug in prboom+ that has been there since at least the beginning of the commit history stored in git (>20 years).

In vanilla doom, mouse strafe only occurs in multiples of 2, but in prboom+ you can achieve any value. This is not particularly relevant for casual players, but being able to produce values of 1 has a pretty big impact on gliding with mouse strafe (for good or bad depending on the situation).

I don't know exactly when this behaviour changed, but the original is still there in the woof source, so in principal this fix should apply to cl 9 and cl 11 for instance as well. However, I've only changed it for pre-boom complevels. If this kind of behaviour is "wrong" in the port most commonly used for those complevels for recording, for 20 years, it's probably not something we should change. 🤷 