### PR TITLE
preserve complevel after using cheat for the rest of the session

### DIFF
--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -50,7 +50,7 @@ dboolean modifiedgame;
 //-----------------------------------------------------------------------------
 
 // CPhipps - compatibility vars
-complevel_t compatibility_level, default_compatibility_level;
+complevel_t compatibility_level, default_compatibility_level, last_compatibility_level;
 
 // e6y
 // it's required for demos recorded in "demo compatibility" mode by boom201 for example

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -68,7 +68,7 @@ extern const char *doomverstr;
 extern  dboolean modifiedgame;
 
 // CPhipps - new compatibility handling
-extern complevel_t compatibility_level, default_compatibility_level;
+extern complevel_t compatibility_level, default_compatibility_level, last_compatibility_level;
 
 // CPhipps - old compatibility testing flags aliased to new handling
 #define compatibility (compatibility_level<=boom_compatibility_compatibility)

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2694,7 +2694,7 @@ void G_ReloadDefaults(void)
 
   consoleplayer = 0;
 
-  compatibility_level = default_compatibility_level;
+  compatibility_level = last_compatibility_level;
   {
     int i = M_CheckParm("-complevel");
     if (i && (1+i) < myargc) {

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -447,6 +447,7 @@ static void cheat_comp()
 {
   // CPhipps - modified for new compatibility system
   compatibility_level++; compatibility_level %= MAX_COMPATIBILITY_LEVEL;
+  last_compatibility_level = compatibility_level;
   // must call G_Compatibility after changing compatibility_level
   // (fixes sf bug number 1558738)
   G_Compatibility();
@@ -871,7 +872,7 @@ static void cheat_comp_ext(char buf[3])
   if( cl < 0 || cl >= MAX_COMPATIBILITY_LEVEL ) {
     return;
   }
-  compatibility_level = cl;
+  last_compatibility_level = compatibility_level = cl;
   G_Compatibility();
   doom_printf("New compatibility level:\n%s (%d)", comp_lev_str[compatibility_level], compatibility_level);
 }

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1682,6 +1682,8 @@ void M_LoadDefaults (void)
   //e6y: Check on existence of prboom.wad
   if (!(wad_files[0] = I_FindFile(PACKAGE_TARNAME ".wad", "")))
     I_Error("PrBoom-Plus.wad not found. Can't continue.");
+
+  last_compatibility_level = default_compatibility_level;
 }
 
 


### PR DESCRIPTION
Right now it gets replaced with default value from config each time you reset level or change level