### PR TITLE
Fix typo in ZDoom-style Actor name.

### DIFF
--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -164,7 +164,7 @@ RedTorch
 ShortBlueTorch
 ShortGreenTorch
 ShortRedTorch
-Slalagtite
+Stalagtite
 TechPillar
 CandleStick
 Candelabra

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -143,7 +143,7 @@ static const char * const ActorNames[] =
 	"ShortBlueTorch",
 	"ShortGreenTorch",
 	"ShortRedTorch",
-	"Slalagtite",
+	"Stalagtite",
 	"TechPillar",
 	"CandleStick",
 	"Candelabra",


### PR DESCRIPTION
Recommend to fix this before any mods use the typo'd actor name and it splits the naming.