### PR TITLE
Preserve automap position/scale when toggling overlay mode

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -816,8 +816,7 @@ dboolean AM_Responder
     else if (ch == key_map_overlay) {
       automapmode ^= am_overlay;
       AM_SetPosition();
-      AM_SetScale();
-      AM_initVariables();
+      AM_activateNewScale();
       plr->message = (automapmode & am_overlay) ? s_AMSTR_OVERLAYON : s_AMSTR_OVERLAYOFF;
     }
 #ifdef GL_DOOM


### PR DESCRIPTION
Currently, toggling the automap overlay mode on/off causes the automap's position and scale to reset to the player's position and the default zoom level, which is inconvenient if you've scrolled to a different part of the map and want to deactivate overlay mode for a bit to get a better look at the automap.