### PR TITLE
disable sound cutoffs

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3174,16 +3174,17 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
   {"Status Bar and Menu Appearance", S_CHOICE,           m_null, G_X, G_Y+ 6*8, {"render_stretch_hud"}, 0, 0, M_ChangeStretch, render_stretch_list},
   {"Vertical Sync",                  S_YESNO,            m_null, G_X, G_Y+ 7*8, {"render_vsync"}, 0, 0, M_ChangeVideoMode},
   
-  {"Enable Translucency",            S_YESNO,            m_null, G_X, G_Y+10*8, {"translucency"}, 0, 0, M_Trans},
-  {"Translucency filter percentage", S_NUM,              m_null, G_X, G_Y+11*8, {"tran_filter_pct"}, 0, 0, M_Trans},
-  {"Uncapped Framerate",             S_YESNO,            m_null, G_X, G_Y+12*8, {"uncapped_framerate"}, 0, 0, M_ChangeUncappedFrameRate},
+  {"Enable Translucency",            S_YESNO,            m_null, G_X, G_Y+ 9*8, {"translucency"}, 0, 0, M_Trans},
+  {"Translucency filter percentage", S_NUM,              m_null, G_X, G_Y+10*8, {"tran_filter_pct"}, 0, 0, M_Trans},
+  {"Uncapped Framerate",             S_YESNO,            m_null, G_X, G_Y+11*8, {"uncapped_framerate"}, 0, 0, M_ChangeUncappedFrameRate},
 
-  {"Sound & Music",                  S_SKIP|S_TITLE,     m_null, G_X, G_Y+14*8},
-  {"Number of Sound Channels",       S_NUM|S_PRGWARN,    m_null, G_X, G_Y+15*8, {"snd_channels"}},
-  {"Enable v1.1 Pitch Effects",      S_YESNO,            m_null, G_X, G_Y+16*8, {"pitched_sounds"}},
-  {"PC Speaker emulation",           S_YESNO|S_PRGWARN,  m_null, G_X, G_Y+17*8, {"snd_pcspeaker"}},
-  {"Preferred MIDI player",          S_CHOICE|S_PRGWARN, m_null, G_X, G_Y+18*8, {"snd_midiplayer"}, 0, 0, M_ChangeMIDIPlayer, midiplayers},
-  {"Low-pass filter",                S_YESNO,            m_null, G_X, G_Y+19*8, {"lowpass_filter"}},
+  {"Sound & Music",                  S_SKIP|S_TITLE,     m_null, G_X, G_Y+13*8},
+  {"Number of Sound Channels",       S_NUM|S_PRGWARN,    m_null, G_X, G_Y+14*8, {"snd_channels"}},
+  {"Enable v1.1 Pitch Effects",      S_YESNO,            m_null, G_X, G_Y+15*8, {"pitched_sounds"}},
+  {"PC Speaker emulation",           S_YESNO|S_PRGWARN,  m_null, G_X, G_Y+16*8, {"snd_pcspeaker"}},
+  {"Preferred MIDI player",          S_CHOICE|S_PRGWARN, m_null, G_X, G_Y+17*8, {"snd_midiplayer"}, 0, 0, M_ChangeMIDIPlayer, midiplayers},
+  {"Low-pass filter",                S_YESNO,            m_null, G_X, G_Y+18*8, {"lowpass_filter"}},
+  {"disable sound cutoffs",          S_YESNO,            m_null, G_X, G_Y+19*8, {"full_sounds"}},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -447,6 +447,7 @@ default_t defaults[] =
   {"snd_mididev",{NULL, &snd_mididev},{0,""},UL,UL,def_str,ss_none}, // midi device to use for portmidiplayer
   {"lowpass_filter",{&lowpass_filter},{0},0,1,
   def_bool,ss_none}, // low-pass filter borrowed from Chocolate Doom so upscaling old audio doesn't sound too horrible
+  {"full_sounds",{&full_sounds},{0},0,1,def_bool,ss_none}, // disable sound cutoffs
 
 #ifdef _WIN32
   {"mus_extend_volume",{&mus_extend_volume},{0},0,1,

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -1100,7 +1100,12 @@ void A_Look(mobj_t *actor)
       if (actor->type==MT_SPIDER || actor->type == MT_CYBORG)
         S_StartSound(NULL, sound);          // full volume
       else
+      {
         S_StartSound(actor, sound);
+       // [FG] make seesounds uninterruptible
+        if (full_sounds)
+          S_UnlinkSound(actor);
+      }
     }
   P_SetMobjState(actor, actor->info->seestate);
 }

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -996,7 +996,11 @@ void P_RemoveMobj (mobj_t* mobj)
 
   // stop any playing sound
 
-  S_StopSound (mobj);
+  // [FG] removed map objects may finish their sounds
+  if (full_sounds)
+    S_UnlinkSound(mobj);
+  else
+    S_StopSound (mobj);
 
   // killough 11/98:
   //

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -81,6 +81,7 @@ typedef struct
 
 // the set of channels available
 static channel_t *channels;
+static degenmobj_t *sobjs;
 
 // These are not used, but should be (menu).
 // Maximum volume of a sound effect.
@@ -147,6 +148,8 @@ void S_Init(int sfxVolume, int musicVolume)
     // CPhipps - calloc
     channels =
       (channel_t *) calloc(numChannels,sizeof(channel_t));
+    sobjs =
+      (degenmobj_t *) calloc(numChannels, sizeof(degenmobj_t));
 
     // Note that sounds have not been cached (yet).
     for (i=1 ; i<NUMSFX ; i++)
@@ -358,6 +361,34 @@ void S_StopSound(void *origin)
       }
 }
 
+// [FG] disable sound cutoffs
+int full_sounds;
+
+void S_UnlinkSound(void *origin)
+{
+  int cnum;
+
+  //jff 1/22/98 return if sound is not enabled
+  if (!snd_card || nosfxparm)
+    return;
+
+  if (origin)
+  {
+    for (cnum = 0; cnum < numChannels; cnum++)
+    {
+      if (channels[cnum].sfxinfo && channels[cnum].origin == origin)
+      {
+        degenmobj_t *const sobj = &sobjs[cnum];
+        const mobj_t *const mobj = (mobj_t *) origin;
+        sobj->x = mobj->x;
+        sobj->y = mobj->y;
+        sobj->z = mobj->z;
+        channels[cnum].origin = (mobj_t *) sobj;
+        break;
+      }
+    }
+  }
+}
 
 //
 // Stop and resume music, during game PAUSE.

--- a/prboom2/src/s_sound.h
+++ b/prboom2/src/s_sound.h
@@ -70,6 +70,9 @@ void S_StartSoundAtVolume(void *origin, int sound_id, int volume);
 // Stop sound for thing at <origin>
 void S_StopSound(void* origin);
 
+extern int full_sounds;
+void S_UnlinkSound(void *origin);
+
 // Start music using <music_id> from sounds.h
 void S_StartMusic(int music_id);
 


### PR DESCRIPTION
* removed map objects may finish their sounds
* make seesounds uninterruptible

Fixes #186