### PR TITLE
Fix hanging notes on exit when using Portmidi (fixes #232)

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -185,7 +185,7 @@ static int pm_init (int samplerate)
 
 #endif
 
-static void pm_killnotes (unsigned long when = 0)
+static void pm_killnotes (unsigned long when)
 {
   /*
   workaround to hanging notes with portmidi; send "All Sound Off"
@@ -234,7 +234,7 @@ static void pm_shutdown (void)
     #endif
 
 	// stop all sound, in case of hanging notes
-    pm_killnotes();
+    pm_killnotes(0);
 
     Pm_Close (pm_stream);
     Pm_Terminate ();

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -208,9 +208,7 @@ static void pm_shutdown (void)
     
     not a fix: calling Pm_Abort(); then midiStreamStop deadlocks instead of midiStreamClose. 
     */
-    #ifdef _WIN32
     Pt_Sleep (DRIVER_LATENCY * 2);
-    #endif
 
     Pm_Close (pm_stream);
     Pm_Terminate ();

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -178,6 +178,8 @@ static int pm_init (int samplerate)
   return 1;
 }
 
+static void pm_stop (void);
+
 static void pm_shutdown (void)
 {
   if (pm_stream)

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -390,7 +390,7 @@ static void writesysex (unsigned long when, int etype, unsigned char *data, int 
 static void pm_stop (void)
 {
   int i;
-  unsigned long when = Pt_Time ();
+  unsigned long when = 0;
   pm_playing = 0;
   
 

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -388,7 +388,7 @@ static void writesysex (unsigned long when, int etype, unsigned char *data, int 
 static void pm_stop (void)
 {
   int i;
-  unsigned long when = 0;
+  unsigned long when = Pt_Time ();
   pm_playing = 0;
   
 

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -185,6 +185,9 @@ static int pm_init (int samplerate)
 
 #endif
 
+// forward declaration, good enough for the time being
+static void writeevent (unsigned long when, int eve, int channel, int v1, int v2);
+
 static void pm_killnotes (unsigned long when)
 {
   /*

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -195,6 +195,9 @@ static void pm_killnotes (unsigned long when)
 
   the event would be Bn 78 00, where 'n' is a MIDI channel; eg. the
   MIDI message B1 78 00 stops all sound in channel 2 (of 1-16)
+
+  'when' is a midi timestamp value. if in doubt, pass 0, to stop all
+  notes right now·
   */
 
   when = when | (Pt_Time() * !when); // set when to Pt_Time() if when is zero

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -178,26 +178,19 @@ static int pm_init (int samplerate)
   return 1;
 }
 
-#ifndef MIDI_EVENT_CHANNEL_MODE
-
-// channel mode events in MIDI, low nibble is channel value as usual
-#define MIDI_EVENT_CHANNEL_MODE 0xB0
-
-#endif
-
 // forward declaration, good enough for the time being
 static void writeevent (unsigned long when, int eve, int channel, int v1, int v2);
 
 static void pm_killnotes (unsigned long when)
 {
   /*
-  workaround to hanging notes with portmidi; send "All Sound Off"
+  workaround to hanging notes with portmidi; send "All Notes Off"
   events to all channels when the game exits
 
   see: http://personal.kent.edu/~sbirch/Music_Production/MP-II/MIDI/midi_channel_mode_messages.htm
 
-  the event would be Bn 78 00, where 'n' is a MIDI channel; eg. the
-  MIDI message B1 78 00 stops all sound in channel 2 (of 1-16)
+  the event would be Bn 7B 00, where 'n' is a MIDI channel; eg. the
+  MIDI message B1 7B 00 sends All Notes Off in channel 2 (of 1-16)
 
   'when' is a midi timestamp value. if in doubt, pass 0, to stop all
   notes right now·
@@ -205,8 +198,8 @@ static void pm_killnotes (unsigned long when)
 
   when = when | (Pt_Time() * !when); // set when to Pt_Time() if when is zero
 
-  for (int ch = 0; ch < 16; ch++) {
-    writeevent (when, MIDI_EVENT_CHANNEL_MODE, ch, 0x78, 0x00);
+  for (int ch = 0; ch < 0xF; ch++) {
+    writeevent (when, 0xB0, ch, 0x7B, 0x00);
   }
 }
 


### PR DESCRIPTION
When using the PortMidi player, e.g. in an ALSA MIDI setup, closing the program often [leaves some hanging notes](https://github.com/coelckers/prboom-plus/issues/232), since they aren't stopped by the game when it exits.

This hopefully fixes it by sending a MIDI ~~Stop All Sound~~ All Notes Off message to all channels in the shutdown callback, right before actually shutting PortMidi itself down, and by allowing the delay between that and the Portmidi shutdown to happen on non-Win32 platforms too.

Also, for the sake of linkage. Fixes #232 .