### PR TITLE
Fix P_SetMobjState stack

### DIFF
--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -71,10 +71,10 @@ dboolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   static int recursion;                       // detects recursion
   statenum_t i = state;                       // initial state
   dboolean ret = true;                         // return value
-  statenum_t tempstate[NUMSTATES];            // for use with recursion
+  statenum_t* tempstate = NULL;               // for use with recursion
 
   if (recursion++)                            // if recursion detected,
-    memset(seenstate=tempstate,0,sizeof tempstate); // clear state table
+    seenstate = tempstate = calloc(NUMSTATES, sizeof(statenum_t)); // allocate state table
 
   do
     {
@@ -109,6 +109,9 @@ dboolean P_SetMobjState(mobj_t* mobj,statenum_t state)
   if (!--recursion)
     for (;(state=seenstate[i]);i=state-1)
       seenstate[i] = 0;  // killough 4/9/98: erase memory of states
+
+  if (tempstate)
+    free(tempstate);
 
   return ret;
 }


### PR DESCRIPTION
If you try to play back Map 31 UV Max from https://dsdarchive.com/wads/mayhem18p you may crash on windows, because we run out of stack space (linux seems to usually have more stack space).

The P_SetMobjState method exhibits recursion and allocates a 4k integer array onto the stack. In the aforementioned demo, the recursion reaches a depth of over 150, which yields 600k integers on the stack from this method alone (it isn't the only method in the chain).

This PR allocates the 4k state tracking table onto the heap instead, which prevents the crash from happening.