### PR TITLE
Fix a crash when viewing the automap with sprites and iddt

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1762,7 +1762,7 @@ static void AM_ProcessNiceThing(mobj_t* mobj, angle_t angle, fixed_t x, fixed_t 
     {SPR_BFS1, am_icon_bullet, 12, 0, 119, 255, 111},
     {SPR_BFE1, am_icon_bullet, 12, 0, 119, 255, 111},
 
-    {-1}
+    {NUMSPRITES}
   };
 
   need_shadow = true;
@@ -1816,7 +1816,7 @@ static void AM_ProcessNiceThing(mobj_t* mobj, angle_t angle, fixed_t x, fixed_t 
   else
   {
     i = 0;
-    while (icons[i].sprite > 0)
+    while (icons[i].sprite < NUMSPRITES)
     {
       if (mobj->sprite == icons[i].sprite)
       {


### PR DESCRIPTION
I noticed prboom crashed on certain maps when viewing the automap.

To reproduce the problem:
set map_things_appearance to 2 in prboom-plus.cfg
make sure you use openGL renderer
% prboom-plus <wads>/sunlust.wad -warp 01
view automap
iddt twice

The problematic code compares an enum value to -1 which is platform specific behaviour.

I'm running prboom on macos 10.15, compiled with clang 12.0.0