### PR TITLE
Fix menu intermission desync

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1257,7 +1257,7 @@ void G_Ticker (void)
   // e6y
   // do nothing if a pause has been pressed during playback
   // pausing during intermission can cause desynchs without that
-  if (paused & 2 && gamestate != GS_LEVEL)
+  if ((paused & 2 || (!demoplayback && menuactive && !netgame)) && gamestate != GS_LEVEL)
     return;
 
   // do main actions


### PR DESCRIPTION
If you open the menu during intermission while the numbers are ticking down, you will cause a desync. This was reported some time ago but hadn't been addressed yet. Here is the fix.