### PR TITLE
Update comp_respawn comments

### DIFF
--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -109,7 +109,7 @@ enum {
   comp_infcheat,
   comp_zerotags,
   comp_moveblock,
-  comp_respawn,  /* cph - this is the inverse of comp_respawnfix from eternity */
+  comp_respawn,  /* cph - alias of comp_respawnfix from eternity */
   comp_sound,
   comp_666,
   comp_soul,

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -705,9 +705,7 @@ static void P_NightmareRespawn(mobj_t* mobj)
    * regardless of that point's nature. SMMU and Eternity need this for
    * script-spawned things like Halif Swordsmythe, as well.
    *
-   * cph - copied from eternity, except comp_respawnfix becomes comp_respawn
-   *   and the logic is reversed (i.e. like the rest of comp_ it *disables*
-   *   the fix)
+   * cph - copied from eternity, alias comp_respawnfix
    */
   if(!comp[comp_respawn] && !x && !y)
   {


### PR DESCRIPTION
When this comp option was implemented, there was an oversight in EE that had the meaning of the comp option flipped ("on" should always mean "not fixed"). That was fixed in EE some time in the past though, so comp_respawn has the same meaning now. This PR just updates a couple comments in the code to prevent confusion.