### PR TITLE
fix custom episode select for Doom 2

### DIFF
--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -38,7 +38,7 @@ intertextsecret = clear		; Disables default intermission text for the given map'
 interbackdrop = "graphic"	
 							; Backdrop to be used for intertext and intertextsecret. If it does not specify a valid flat, it will be drawn as a patch instead. If not specified the FLOOR4_8 flat will be used, regardless of which map it is used on.
 intermusic = "song"			; Music to be used for intertext and intertextsecret. If not specified D_VICTOR/D_READ_M will be used, depending on the IWAD.
-episode = clear				; Clears the episode menu of all previous entries. Should be used on the first map if a mod wants to define its own episodes. Doom 2 has no episodes by default.
+episode = clear				; Clears the episode menu of all previous entries. Should be used on the first map if a mod wants to define its own episodes. Doom 2 and Chex Quest have no episodes by default.
 episode = "patch", "name", "key"	
 							; Defines an entry for the episode menu. If all defined episodes define a valid patch, those will be shown, otherwise the names will be used with the HUD font. At most 8 episodes can be defined.
 bossaction = thingtype, linespecial, tag
@@ -216,7 +216,7 @@ UnholyBible
 Revisions:
 
 Rev 1.4 (@rfomin, Mar 23 2021)
- * Clarify the 'episode' field in the case of Doom 2.
+ * Clarify the 'episode' field in the case of Doom 2 and Chex Quest.
 
 Rev 1.3 (@fabiangreffrath, Mar 5 2021)
  * If interbackdrop does not specify a valid flat, draw it as a patch instead.

--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -38,7 +38,7 @@ intertextsecret = clear		; Disables default intermission text for the given map'
 interbackdrop = "graphic"	
 							; Backdrop to be used for intertext and intertextsecret. If it does not specify a valid flat, it will be drawn as a patch instead. If not specified the FLOOR4_8 flat will be used, regardless of which map it is used on.
 intermusic = "song"			; Music to be used for intertext and intertextsecret. If not specified D_VICTOR/D_READ_M will be used, depending on the IWAD.
-episode = clear				; Clears the episode menu of all previous entries. Should be used on the first map if a mod wants to define its own episodes.
+episode = clear				; Clears the episode menu of all previous entries. Should be used on the first map if a mod wants to define its own episodes. Doom 2 has no episodes by default.
 episode = "patch", "name", "key"	
 							; Defines an entry for the episode menu. If all defined episodes define a valid patch, those will be shown, otherwise the names will be used with the HUD font. At most 8 episodes can be defined.
 bossaction = thingtype, linespecial, tag
@@ -214,6 +214,9 @@ EvilSceptre
 UnholyBible
 
 Revisions:
+
+Rev 1.4 (@rfomin, Mar 23 2021)
+ * Clarify the 'episode' field in the case of Doom 2.
 
 Rev 1.3 (@fabiangreffrath, Mar 5 2021)
  * If interbackdrop does not specify a valid flat, draw it as a patch instead.

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -573,7 +573,7 @@ void M_AddEpisode(const char *map, char *def)
 		EpiCustom = true;
 		NewDef.prevMenu = &EpiDef;
 
-		if (gamemode == commercial)
+		if (gamemode == commercial || gamemission == chex)
 			EpiDef.numitems = 0;
 	}
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -568,7 +568,15 @@ int epiChoice;
 
 void M_AddEpisode(const char *map, char *def)
 {
-	EpiCustom = true;
+	if (!EpiCustom)
+	{
+		EpiCustom = true;
+		NewDef.prevMenu = &EpiDef;
+
+		if (gamemode == commercial)
+			EpiDef.numitems = 0;
+	}
+
 	if (*def == '-')	// means 'clear'
 	{
 		EpiDef.numitems = 0;
@@ -6283,7 +6291,8 @@ void M_Init(void)
       MainMenu[readthis] = MainMenu[quitdoom];
       MainDef.numitems--;
       MainDef.y += 8;
-      NewDef.prevMenu = &MainDef;
+      if (!EpiCustom)
+        NewDef.prevMenu = &MainDef;
       ReadDef1.routine = M_DrawReadThis1;
       ReadDef1.x = 330;
       ReadDef1.y = 165;


### PR DESCRIPTION
By default, Doom 2 has 4 episodes in the current UMAPINFO implementation. There are few UMAPINFO files out in the wild that don't aware of that.
Before:
![doom00](https://user-images.githubusercontent.com/5077629/112083609-f1fc8180-8bb9-11eb-9a32-125c01724337.png)
After:
![doom00](https://user-images.githubusercontent.com/5077629/112083721-1e180280-8bba-11eb-90ad-220b55815a65.png)

