### PR TITLE
consider translucency and comp_translucency settings on all complevels

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1490,7 +1490,7 @@ void deh_changeCompTranslucency(void)
       }
       else
 #endif
-      if (comp[comp_translucency]) 
+      if (default_comp[comp_translucency])
         mobjinfo[predefined_translucency[i]].flags &= ~MF_TRANSLUCENT;
       else 
         mobjinfo[predefined_translucency[i]].flags |= MF_TRANSLUCENT;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3686,7 +3686,7 @@ setup_menu_t comp_settings3[] =  // Compatibility Settings screen #3
   {"Max Health in DEH applies only to potions", S_YESNO, m_null, C_X,
    C_Y + compat_maxhealth * COMP_SPC, {"comp_maxhealth"}},
   {"No predefined translucency for some things", S_YESNO, m_null, C_X,
-   C_Y + compat_translucency * COMP_SPC, {"comp_translucency"}},
+   C_Y + compat_translucency * COMP_SPC, {"comp_translucency"},0,0,deh_changeCompTranslucency},
    // [FG]
   {"allow MBF sky transfers in all complevels", S_YESNO, m_null, C_X,
    C_Y + compat_skytransfers * COMP_SPC, {"comp_skytransfers"}},


### PR DESCRIPTION
This changes the code to evaluate the user-set
`default_comp[comp_translucency]` value instead of the
`comp[comp_translucency]` value which is computed based on current
complevel.

This allows for translucent sprites on all complevels (fixes #246) and
at the same time allows for disabling predefined translucency on all
complevels (fixes #248). Additionally, the change of the compatibility
option is instantly applied to the current game.