### PR TITLE
[Optimized Implementation] Proposal to Fix flood HOM

### DIFF
--- a/prboom2/src/gl_missingtexture.c
+++ b/prboom2/src/gl_missingtexture.c
@@ -167,7 +167,11 @@ void gld_PreprocessFakeSectors(void)
   int groupid;
 
   if (gl_use_stencil)
+  {
+    // precalculate NO_TOPTEXTURES and NO_BOTTOMTEXTURES flags
+    gld_PrepareSectorSpecialEffects();
     return;
+  }
 
   // free memory
   if (fakeplanes)

--- a/prboom2/src/gl_missingtexture.c
+++ b/prboom2/src/gl_missingtexture.c
@@ -82,6 +82,14 @@ static void gld_PrepareSectorSpecialEffects(void)
 {
   int i, num;
 
+  /* free memory if allocated by previous maps */
+  if (bleedsectors) {
+      free(bleedsectors);
+      numbleedsectors = 0;
+      bleedsectors = NULL;
+  }
+
+
   for (num = 0; num < numsectors; num++)
   {
     // the following is for specialeffects. see r_bsp.c in R_Subsector
@@ -196,7 +204,9 @@ static void gld_RegisterBleedthroughSector(sector_t* source, sector_t* target, i
      * and register it instead */
 
     if ((bleedsectors[source_idx].target == NULL) ||
-             (bleedsectors[source_idx].target && ((ceiling && bleedsectors[source_idx].target->ceilingheight > target->ceilingheight) || (bleedsectors[source_idx].target->floorheight < target->floorheight))))
+        (bleedsectors[source_idx].target &&
+        ((ceiling && bleedsectors[source_idx].target->ceilingheight > target->ceilingheight) ||
+        (bleedsectors[source_idx].target->floorheight < target->floorheight))))
         bleedsectors[source_idx].target = target;
 }
 

--- a/prboom2/src/gl_missingtexture.c
+++ b/prboom2/src/gl_missingtexture.c
@@ -166,9 +166,6 @@ void gld_PreprocessFakeSectors(void)
   int i, j, k, ceiling;
   int groupid;
 
-  if (gl_use_stencil)
-    return;
-
   // free memory
   if (fakeplanes)
   {

--- a/prboom2/src/gl_missingtexture.c
+++ b/prboom2/src/gl_missingtexture.c
@@ -83,12 +83,12 @@ static void gld_PrepareSectorSpecialEffects(void)
   int i, num;
 
   /* free memory if allocated by previous maps */
-  if (bleedsectors) {
+  if (bleedsectors)
+  {
       free(bleedsectors);
       numbleedsectors = 0;
       bleedsectors = NULL;
   }
-
 
   for (num = 0; num < numsectors; num++)
   {
@@ -150,7 +150,6 @@ static void gld_PrepareSectorSpecialEffects(void)
                 gld_RegisterBleedthroughSector(side1->sector,side0->sector,0);
             }
         }
-
       }
       else
       {
@@ -179,19 +178,13 @@ static void gld_RegisterBleedthroughSector(sector_t* source, sector_t* target, i
         if (bleedsectors[i].source == source && bleedsectors[i].ceiling == ceiling)
             source_idx = i;
     
-    if (source_idx == -1) {
+    if (source_idx == -1)
+    {
         /* allocate memory for new sector */
-        if (!bleedsectors) {
-            numbleedsectors = 1;
-            bleedsectors = (bleedthrough_t*) malloc(sizeof(bleedthrough_t));
-            memset(&bleedsectors[0], 0, sizeof(bleedthrough_t));
-        } else {
-            bleedsectors = (bleedthrough_t*) realloc(bleedsectors, (numbleedsectors + 1) * sizeof(bleedthrough_t));
-            memset(&bleedsectors[numbleedsectors], 0, sizeof(bleedthrough_t));
-            numbleedsectors++;
-        }
-
+        bleedsectors = (bleedthrough_t*) realloc(bleedsectors, (numbleedsectors + 1) * sizeof(bleedthrough_t));
         if(!bleedsectors) I_Error("gld_RegisterBleedthroughSector: Out of memory");
+        memset(&bleedsectors[numbleedsectors], 0, sizeof(bleedthrough_t));
+        numbleedsectors++;
 
         source_idx = numbleedsectors - 1;
     }
@@ -202,12 +195,18 @@ static void gld_RegisterBleedthroughSector(sector_t* source, sector_t* target, i
     /* either register the proposed target since it is first,
      * or check if the new proposed target is a better option
      * and register it instead */
-
     if ((bleedsectors[source_idx].target == NULL) ||
         (bleedsectors[source_idx].target &&
-        ((ceiling && bleedsectors[source_idx].target->ceilingheight > target->ceilingheight) ||
-        (bleedsectors[source_idx].target->floorheight < target->floorheight))))
+         (
+          (ceiling && bleedsectors[source_idx].target->ceilingheight > target->ceilingheight)
+           ||
+          (bleedsectors[source_idx].target->floorheight < target->floorheight)
+         )
+        )
+       )
+    {
         bleedsectors[source_idx].target = target;
+    }
 }
 
 sector_t* GetBestBleedSector(sector_t* source, int ceiling)

--- a/prboom2/src/gl_missingtexture.c
+++ b/prboom2/src/gl_missingtexture.c
@@ -166,6 +166,9 @@ void gld_PreprocessFakeSectors(void)
   int i, j, k, ceiling;
   int groupid;
 
+  if (gl_use_stencil)
+    return;
+
   // free memory
   if (fakeplanes)
   {

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -179,6 +179,7 @@ dboolean gld_SphereInFrustum(float x, float y, float z, float radius);
 //missing flats (fake floors and ceilings)
 extern dboolean gl_use_stencil;
 sector_t* GetBestFake(sector_t *sector, int ceiling, int validcount);
+sector_t* GetBestBleedSector(sector_t* source, int ceiling);
 
 //shadows
 typedef struct shadow_params_s

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -40,7 +40,6 @@
 #include "r_bsp.h" // cph - sanity checking
 #include "v_video.h"
 #include "lprintf.h"
-#include "p_spec.h"
 
 int currentsubsectornum;
 
@@ -665,12 +664,12 @@ static void R_Subsector(int num)
     if (V_GetMode() == VID_MODEGL)
     {
       // check if the sector is faked
+      sector_t *tmpsec = NULL;
 
         if(frontsector == sub->sector)
         {
             if (!gl_use_stencil)
             {
-                sector_t *tmpsec;
 
                 // if the sector has bottomtextures, then the floorheight will be set to the
                 // highest surounding floorheight
@@ -701,8 +700,6 @@ static void R_Subsector(int num)
                     }
                 }
             }
-
-            sector_t* tmpsec = NULL;
 
             /*
              * Floors higher than the player's viewheight, or ceilings lower

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -40,6 +40,7 @@
 #include "r_bsp.h" // cph - sanity checking
 #include "v_video.h"
 #include "lprintf.h"
+#include "p_spec.h"
 
 int currentsubsectornum;
 
@@ -700,37 +701,37 @@ static void R_Subsector(int num)
                     }
                 }
             }
-            else
+
+            sector_t *tmpsec = { 0 };
+
+            // if the sector has bottomtextures, then the floorheight will be set to the
+            // highest surounding floorheight
+            if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane)))
             {
-                sector_t *tmpsec;
+                fixed_t tgtheight = P_FindLowestFloorSurrounding(frontsector);
+                tmpsec = P_FindModelFloorSector(tgtheight, frontsector->iSectorID);
 
-                // if the sector has bottomtextures, then the floorheight will be set to the
-                // highest surounding floorheight
-                if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane)))
+                if (tmpsec)
                 {
-                    tmpsec = GetBestFake(frontsector, 0, validcount);
-
-                    if (tmpsec)
-                    {
-                        dummyfloorplane.height = P_FindLowestFloorSurrounding(frontsector);
-                        dummyfloorplane.lightlevel = tmpsec->lightlevel;
-                        dummyfloorplane.picnum = tmpsec->floorpic;
-                        floorplane = &dummyfloorplane;
-                    }
+                    dummyfloorplane.height = tgtheight;
+                    dummyfloorplane.lightlevel = tmpsec->lightlevel;
+                    dummyfloorplane.picnum = tmpsec->floorpic;
+                    floorplane = &dummyfloorplane;
                 }
+            }
 
-                // the same for ceilings. they will be set to the lowest ceilingheight
-                if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane)))
+            // the same for ceilings. they will be set to the lowest ceilingheight
+            if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane)))
+            {
+                fixed_t tgtheight = P_FindHighestCeilingSurrounding(frontsector);
+                tmpsec = P_FindModelCeilingSector(tgtheight, frontsector->iSectorID);
+
+                if (tmpsec)
                 {
-                    tmpsec = GetBestFake(frontsector, 1, validcount);
-
-                    if (tmpsec)
-                    {
-                        dummyceilingplane.height = P_FindHighestCeilingSurrounding(frontsector);
-                        dummyceilingplane.lightlevel = tmpsec->lightlevel;
-                        dummyceilingplane.picnum = tmpsec->ceilingpic;
-                        ceilingplane = &dummyceilingplane;
-                    }
+                    dummyceilingplane.height = tgtheight;
+                    dummyceilingplane.lightlevel = tmpsec->lightlevel;
+                    dummyceilingplane.picnum = tmpsec->ceilingpic;
+                    ceilingplane = &dummyceilingplane;
                 }
             }
         }

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -704,8 +704,25 @@ static void R_Subsector(int num)
 
             sector_t *tmpsec = { 0 };
 
-            // if the sector has bottomtextures, then the floorheight will be set to the
-            // highest surounding floorheight
+            /*
+             * Floors higher than the player's viewheight, or ceilings lower
+             * than the player's viewheight with no textures will bleed the
+             * sector behind them through in the software renderer. This is
+             * occasionally used to create an "invisible wall" effect to hide
+             * monsters, but in the GL renderer would leave an untextured space
+             * beneath or above unless otherwise patched.
+             *
+             * This code attempts to find an appropriate sector to "bleed
+             * through" over the untextured gap.
+             *
+             * Note there is a corner case that is not handled: If a dummy
+             * sector off-screen is the lowest adjacent sector to the invisible
+             * wall, and it is at a different height than the correct
+             * bleed-through sector, the dummy sector is copied instead of the
+             * sector behind the player. It may be possible to address this in
+             * a future patch by refactoring this into the renderer and tagging
+             * visible candidate sectors during drawing.
+             */
             if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane)))
             {
                 fixed_t tgtheight = P_FindLowestFloorSurrounding(frontsector);
@@ -720,7 +737,6 @@ static void R_Subsector(int num)
                 }
             }
 
-            // the same for ceilings. they will be set to the lowest ceilingheight
             if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane)))
             {
                 fixed_t tgtheight = P_FindHighestCeilingSurrounding(frontsector);

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -706,13 +706,13 @@ static void R_Subsector(int num)
 
                 // if the sector has bottomtextures, then the floorheight will be set to the
                 // highest surounding floorheight
-                if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!ceilingplane)))
+                if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane)))
                 {
-                    tmpsec = GetBestFake(frontsector, 1, validcount);
+                    tmpsec = GetBestFake(frontsector, 0, validcount);
 
-                    if (tmpsec && frontsector->floorheight != tmpsec->floorheight)
+                    if (tmpsec)
                     {
-                        dummyfloorplane.height = tmpsec->floorheight;
+                        dummyfloorplane.height = P_FindLowestFloorSurrounding(frontsector);
                         dummyfloorplane.lightlevel = tmpsec->lightlevel;
                         dummyfloorplane.picnum = tmpsec->floorpic;
                         floorplane = &dummyfloorplane;
@@ -720,13 +720,13 @@ static void R_Subsector(int num)
                 }
 
                 // the same for ceilings. they will be set to the lowest ceilingheight
-                if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!floorplane)))
+                if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane)))
                 {
-                    tmpsec = GetBestFake(frontsector, 0, validcount);
+                    tmpsec = GetBestFake(frontsector, 1, validcount);
 
-                    if (tmpsec && frontsector->ceilingheight != tmpsec->ceilingheight)
+                    if (tmpsec)
                     {
-                        dummyceilingplane.height = tmpsec->ceilingheight;
+                        dummyceilingplane.height = P_FindHighestCeilingSurrounding(frontsector);
                         dummyceilingplane.lightlevel = tmpsec->lightlevel;
                         dummyceilingplane.picnum = tmpsec->ceilingpic;
                         ceilingplane = &dummyceilingplane;

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -706,7 +706,7 @@ static void R_Subsector(int num)
 
                 // if the sector has bottomtextures, then the floorheight will be set to the
                 // highest surounding floorheight
-                if ((frontsector->flags & NO_BOTTOMTEXTURES) || (!ceilingplane))
+                if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!ceilingplane)))
                 {
                     tmpsec = GetBestFake(frontsector, 1, validcount);
 
@@ -720,7 +720,7 @@ static void R_Subsector(int num)
                 }
 
                 // the same for ceilings. they will be set to the lowest ceilingheight
-                if ((frontsector->flags & NO_TOPTEXTURES) || (!floorplane))
+                if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!floorplane)))
                 {
                     tmpsec = GetBestFake(frontsector, 0, validcount);
 

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -664,39 +664,76 @@ static void R_Subsector(int num)
     if (V_GetMode() == VID_MODEGL)
     {
       // check if the sector is faked
-      if (!gl_use_stencil && frontsector == sub->sector)
-      {
-        sector_t *tmpsec;
 
-        // if the sector has bottomtextures, then the floorheight will be set to the
-        // highest surounding floorheight
-        if ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane))
+        if(frontsector == sub->sector)
         {
-          tmpsec = GetBestFake(frontsector, 0, validcount);
+            if (!gl_use_stencil)
+            {
+                sector_t *tmpsec;
 
-          if (tmpsec && frontsector->floorheight != tmpsec->floorheight)
-          {
-            dummyfloorplane.height = tmpsec->floorheight;
-            dummyfloorplane.lightlevel = tmpsec->lightlevel;
-            dummyfloorplane.picnum = tmpsec->floorpic;
-            floorplane = &dummyfloorplane;
-          }
+                // if the sector has bottomtextures, then the floorheight will be set to the
+                // highest surounding floorheight
+                if ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane))
+                {
+                    tmpsec = GetBestFake(frontsector, 0, validcount);
+
+                    if (tmpsec && frontsector->floorheight != tmpsec->floorheight)
+                    {
+                        dummyfloorplane.height = tmpsec->floorheight;
+                        dummyfloorplane.lightlevel = tmpsec->lightlevel;
+                        dummyfloorplane.picnum = tmpsec->floorpic;
+                        floorplane = &dummyfloorplane;
+                    }
+                }
+
+                // the same for ceilings. they will be set to the lowest ceilingheight
+                if ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane))
+                {
+                    tmpsec = GetBestFake(frontsector, 1, validcount);
+
+                    if (tmpsec && frontsector->ceilingheight != tmpsec->ceilingheight)
+                    {
+                        dummyceilingplane.height = tmpsec->ceilingheight;
+                        dummyceilingplane.lightlevel = tmpsec->lightlevel;
+                        dummyceilingplane.picnum = tmpsec->ceilingpic;
+                        ceilingplane = &dummyceilingplane;
+                    }
+                }
+            }
+            else
+            {
+                sector_t *tmpsec;
+
+                // if the sector has bottomtextures, then the floorheight will be set to the
+                // highest surounding floorheight
+                if ((frontsector->flags & NO_BOTTOMTEXTURES) || (!ceilingplane))
+                {
+                    tmpsec = GetBestFake(frontsector, 1, validcount);
+
+                    if (tmpsec && frontsector->floorheight != tmpsec->floorheight)
+                    {
+                        dummyfloorplane.height = tmpsec->floorheight;
+                        dummyfloorplane.lightlevel = tmpsec->lightlevel;
+                        dummyfloorplane.picnum = tmpsec->floorpic;
+                        floorplane = &dummyfloorplane;
+                    }
+                }
+
+                // the same for ceilings. they will be set to the lowest ceilingheight
+                if ((frontsector->flags & NO_TOPTEXTURES) || (!floorplane))
+                {
+                    tmpsec = GetBestFake(frontsector, 0, validcount);
+
+                    if (tmpsec && frontsector->ceilingheight != tmpsec->ceilingheight)
+                    {
+                        dummyceilingplane.height = tmpsec->ceilingheight;
+                        dummyceilingplane.lightlevel = tmpsec->lightlevel;
+                        dummyceilingplane.picnum = tmpsec->ceilingpic;
+                        ceilingplane = &dummyceilingplane;
+                    }
+                }
+            }
         }
-
-        // the same for ceilings. they will be set to the lowest ceilingheight
-        if ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane))
-        {
-          tmpsec = GetBestFake(frontsector, 1, validcount);
-
-          if (tmpsec && frontsector->ceilingheight != tmpsec->ceilingheight)
-          {
-            dummyceilingplane.height = tmpsec->ceilingheight;
-            dummyceilingplane.lightlevel = tmpsec->lightlevel;
-            dummyceilingplane.picnum = tmpsec->ceilingpic;
-            ceilingplane = &dummyceilingplane;
-          }
-        }
-      }
     }
 #endif
 

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -702,7 +702,7 @@ static void R_Subsector(int num)
                 }
             }
 
-            sector_t *tmpsec = { 0 };
+            sector_t* tmpsec = NULL;
 
             /*
              * Floors higher than the player's viewheight, or ceilings lower

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -723,7 +723,7 @@ static void R_Subsector(int num)
              * a future patch by refactoring this into the renderer and tagging
              * visible candidate sectors during drawing.
              */
-            if (frontsector->floorheight >= viewz && ((frontsector->flags & NO_BOTTOMTEXTURES) || (!floorplane)))
+            if (frontsector->floorheight >= viewz && (frontsector->flags & NO_BOTTOMTEXTURES))
             {
                 fixed_t tgtheight = P_FindLowestFloorSurrounding(frontsector);
                 tmpsec = P_FindModelFloorSector(tgtheight, frontsector->iSectorID);
@@ -737,7 +737,7 @@ static void R_Subsector(int num)
                 }
             }
 
-            if (frontsector->ceilingheight <= viewz && ((frontsector->flags & NO_TOPTEXTURES) || (!ceilingplane)))
+            if (frontsector->ceilingheight <= viewz && (frontsector->flags & NO_TOPTEXTURES))
             {
                 fixed_t tgtheight = P_FindHighestCeilingSurrounding(frontsector);
                 tmpsec = P_FindModelCeilingSector(tgtheight, frontsector->iSectorID);

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -725,12 +725,11 @@ static void R_Subsector(int num)
              */
             if (frontsector->floorheight >= viewz && (frontsector->flags & MISSING_BOTTOMTEXTURES))
             {
-                fixed_t tgtheight = P_FindLowestFloorSurrounding(frontsector);
-                tmpsec = P_FindModelFloorSector(tgtheight, frontsector->iSectorID);
+                tmpsec = GetBestBleedSector(frontsector, 0);
 
                 if (tmpsec)
                 {
-                    dummyfloorplane.height = tgtheight;
+                    dummyfloorplane.height = tmpsec->floorheight;
                     dummyfloorplane.lightlevel = tmpsec->lightlevel;
                     dummyfloorplane.picnum = tmpsec->floorpic;
                     floorplane = &dummyfloorplane;
@@ -739,12 +738,11 @@ static void R_Subsector(int num)
 
             if (frontsector->ceilingheight <= viewz && (frontsector->flags & MISSING_TOPTEXTURES))
             {
-                fixed_t tgtheight = P_FindHighestCeilingSurrounding(frontsector);
-                tmpsec = P_FindModelCeilingSector(tgtheight, frontsector->iSectorID);
+                tmpsec = GetBestBleedSector(frontsector, 1);
 
                 if (tmpsec)
                 {
-                    dummyceilingplane.height = tgtheight;
+                    dummyceilingplane.height = tmpsec->ceilingheight;
                     dummyceilingplane.lightlevel = tmpsec->lightlevel;
                     dummyceilingplane.picnum = tmpsec->ceilingpic;
                     ceilingplane = &dummyceilingplane;

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -723,7 +723,7 @@ static void R_Subsector(int num)
              * a future patch by refactoring this into the renderer and tagging
              * visible candidate sectors during drawing.
              */
-            if (frontsector->floorheight >= viewz && (frontsector->flags & NO_BOTTOMTEXTURES))
+            if (frontsector->floorheight >= viewz && (frontsector->flags & MISSING_BOTTOMTEXTURES))
             {
                 fixed_t tgtheight = P_FindLowestFloorSurrounding(frontsector);
                 tmpsec = P_FindModelFloorSector(tgtheight, frontsector->iSectorID);
@@ -737,7 +737,7 @@ static void R_Subsector(int num)
                 }
             }
 
-            if (frontsector->ceilingheight <= viewz && (frontsector->flags & NO_TOPTEXTURES))
+            if (frontsector->ceilingheight <= viewz && (frontsector->flags & MISSING_TOPTEXTURES))
             {
                 fixed_t tgtheight = P_FindHighestCeilingSurrounding(frontsector);
                 tmpsec = P_FindModelCeilingSector(tgtheight, frontsector->iSectorID);

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -95,10 +95,12 @@ typedef struct
 // Stores things/mobjs.
 //
 
-#define NO_TOPTEXTURES        0x00000001
-#define NO_BOTTOMTEXTURES     0x00000002
-#define SECTOR_IS_CLOSED      0x00000004
-#define NULL_SECTOR           0x00000008
+#define NO_TOPTEXTURES             0x00000001
+#define NO_BOTTOMTEXTURES          0x00000002
+#define SECTOR_IS_CLOSED           0x00000004
+#define NULL_SECTOR                0x00000008
+#define MISSING_TOPTEXTURES        0x00000010
+#define MISSING_BOTTOMTEXTURES     0x00000020
 
 typedef struct
 {


### PR DESCRIPTION
Gaps in flat rendering cause a HOM void in the GL renderer where the software renderer would bleed through the flat behind the void. This code is an initial attempt to remedy this (see #226). 

There are a few drawbacks:

* It pulls `P_Spec` calls into `R_Bsp` which is not ideal from an encapsulation perspective.
* A known corner case exists if an off-screen control sector is adjacent to the on-screen sector at a lower/higher sector height. This will cause the fake flat to take on the properties of the wrong sector. However, due to the nature of this effect, I have never seen the sector effect used this way and I suspect it may be rare to never.

Comment is invited as I believe there are many ways to fix this, and some may see advantages to one approach over others.