### PR TITLE
Fix shifting automap markers

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2142,22 +2142,22 @@ static void AM_drawMarks(void)
               if (am_frame.precise)
               {
                 V_DrawNamePatchPrecise(
-                  (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_STRETCH);
+                  (float)p.fx / patches_scalex, (float)p.fy * 200.0f / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
               }
               else
               {
                 V_DrawNamePatch(
-                  p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_STRETCH);
+                  p.x / patches_scalex, p.y * 200 / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
               }
             }
 
             w += markpoints[i].widths[k] + 1;
-            p.x += w * SCREENWIDTH / 320;
+            p.x += w * patches_scalex;
             if (am_frame.precise)
             {
-              p.fx += (float)w * SCREENWIDTH / 320.0f;
+              p.fx += (float)w * patches_scalex;
             }
           }
         }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2185,30 +2185,10 @@ static void AM_drawMarks(void)
           }
 
           w += markpoints[i].widths[k] + 1;
-
-          switch (render_stretch_hud)
+          p.x += w * SCREENWIDTH / 320;
+          if (am_frame.precise)
           {
-            case patch_stretch_16x10:
-              p.x += w * patches_scalex;
-              if (am_frame.precise)
-              {
-                p.fx += (float)w * patches_scalex;
-              }
-              break;
-            case patch_stretch_4x3:
-              p.x += w * WIDE_SCREENWIDTH / 320;
-              if (am_frame.precise)
-              {
-                p.fx += (float)w * WIDE_SCREENWIDTH / 320.0f;
-              }
-              break;
-            case patch_stretch_full:
-              p.x += w * SCREENWIDTH / 320;
-              if (am_frame.precise)
-              {
-                p.fx += (float)w * SCREENWIDTH / 320.0f;
-              }
-              break;
+            p.fx += (float)w * SCREENWIDTH / 320.0f;
           }
         }
       }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2157,13 +2157,13 @@ static void AM_drawMarks(void)
                 if (am_frame.precise)
                 {
                   V_DrawNamePatchPrecise(
-                    (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
+                    (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / WIDE_SCREENHEIGHT,
                     FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
                 }
                 else
                 {
                   V_DrawNamePatch(
-                    p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
+                    p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / WIDE_SCREENHEIGHT,
                     FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
                 }
                 break;

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2137,50 +2137,47 @@ static void AM_drawMarks(void)
           if (p.x < f_x + f_w &&
               p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
           {
+            float fx, fy;
+            int x, y, flags;
+
             switch (render_stretch_hud)
             {
               case patch_stretch_16x10:
-                if (am_frame.precise)
-                {
-                  V_DrawNamePatchPrecise(
-                    (float)p.fx / patches_scalex, (float)p.fy * 200.0f / SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-                }
-                else
-                {
-                  V_DrawNamePatch(
-                    p.x / patches_scalex, p.y * 200 / SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-                }
+                fx = (float)p.fx / patches_scalex;
+                fy = (float)p.fy * 200.0f / SCREENHEIGHT;
+
+                x = p.x / patches_scalex;
+                y = p.y * 200 / SCREENHEIGHT;
+
+                flags = VPT_ALIGN_LEFT | VPT_STRETCH;
                 break;
               case patch_stretch_4x3:
-                if (am_frame.precise)
-                {
-                  V_DrawNamePatchPrecise(
-                    (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / WIDE_SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-                }
-                else
-                {
-                  V_DrawNamePatch(
-                    p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / WIDE_SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-                }
+                fx = (float)p.fx * 320.0f / WIDE_SCREENWIDTH;
+                fy = (float)p.fy * 200.0f / WIDE_SCREENHEIGHT;
+
+                x = p.x * 320 / WIDE_SCREENWIDTH;
+                y = p.y * 200 / WIDE_SCREENHEIGHT;
+                
+                flags = VPT_ALIGN_LEFT | VPT_STRETCH;
                 break;
               case patch_stretch_full:
-                if (am_frame.precise)
-                {
-                  V_DrawNamePatchPrecise(
-                    (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
-                }
-                else
-                {
-                  V_DrawNamePatch(
-                    p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
-                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
-                }
+                fx = (float)p.fx * 320.0f / SCREENWIDTH;
+                fy = (float)p.fy * 200.0f / SCREENHEIGHT;
+
+                x = p.x * 320 / SCREENWIDTH;
+                y = p.y * 200 / SCREENHEIGHT;
+                
+                flags = VPT_ALIGN_WIDE | VPT_STRETCH;
                 break;
+            }
+
+            if (am_frame.precise)
+            {
+              V_DrawNamePatchPrecise(fx, fy, FB, namebuf, CR_DEFAULT, flags);
+            }
+            else
+            {
+              V_DrawNamePatch(x, y, FB, namebuf, CR_DEFAULT, flags);
             }
           }
 

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2117,45 +2117,138 @@ static void AM_drawMarks(void)
       else
         AM_SetMPointFloatValue(&p);
 
-      p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
-      p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
-      if (am_frame.precise)
+      if (render_stretch_hud == 0)
       {
-        p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
-        p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
-      }
-
-      if (V_GetMode() == VID_MODEGL ? 
-          p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
-          p.y < f_y + f_h && p.y >= f_y)
-      {
-        w = 0;
-        for (k = 0; k < (int)strlen(markpoints[i].label); k++)
+        p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
+        p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
+        if (am_frame.precise)
         {
-          namebuf[6] = markpoints[i].label[k];
+          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
+          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
+        }
 
-          if (p.x < f_x + f_w &&
-              p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
+        if (V_GetMode() == VID_MODEGL ? 
+            p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
+            p.y < f_y + f_h && p.y >= f_y)
+        {
+          w = 0;
+          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
           {
+            namebuf[6] = markpoints[i].label[k];
+
+            if (p.x < f_x + f_w &&
+                p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
+            {
+              if (am_frame.precise)
+              {
+                V_DrawNamePatchPrecise(
+                  (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_STRETCH);
+              }
+              else
+              {
+                V_DrawNamePatch(
+                  p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_STRETCH);
+              }
+            }
+
+            w += markpoints[i].widths[k] + 1;
+            p.x += w * SCREENWIDTH / 320;
             if (am_frame.precise)
             {
-              V_DrawNamePatchPrecise(
-                (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
-                FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
-            }
-            else
-            {
-              V_DrawNamePatch(
-                p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
-                FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+              p.fx += (float)w * SCREENWIDTH / 320.0f;
             }
           }
+        }
+      }
+      else if (render_stretch_hud == 1)
+      {
+        p.x = CXMTOF(p.x) - markpoints[i].w * WIDE_SCREENWIDTH / 320 / 2;
+        p.y = CYMTOF(p.y) - markpoints[i].h * WIDE_SCREENHEIGHT / 200 / 2;
+        if (am_frame.precise)
+        {
+          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * WIDE_SCREENWIDTH / 320.0f / 2.0f;
+          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * WIDE_SCREENHEIGHT / 200.0f / 2.0f;
+        }
 
-          w += markpoints[i].widths[k] + 1;
-          p.x += w * SCREENWIDTH / 320;
-          if (am_frame.precise)
+        if (V_GetMode() == VID_MODEGL ? 
+            p.y < f_y + f_h && p.y + markpoints[i].h * WIDE_SCREENHEIGHT / 200 >= f_y :
+            p.y < f_y + f_h && p.y >= f_y)
+        {
+          w = 0;
+          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
           {
-            p.fx += (float)w * SCREENWIDTH / 320.0f;
+            namebuf[6] = markpoints[i].label[k];
+
+            if (p.x < f_x + f_w &&
+                p.x + markpoints[i].widths[k] * WIDE_SCREENWIDTH / 320 >= f_x)
+            {
+              if (am_frame.precise)
+              {
+                V_DrawNamePatchPrecise(
+                  (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / WIDE_SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+              }
+              else
+              {
+                V_DrawNamePatch(
+                  p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / WIDE_SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+              }
+            }
+
+            w += markpoints[i].widths[k] + 1;
+            p.x += w * WIDE_SCREENWIDTH / 320;
+            if (am_frame.precise)
+            {
+              p.fx += (float)w * WIDE_SCREENWIDTH / 320.0f;
+            }
+          }
+        }
+      }
+      else if (render_stretch_hud == 2)
+      {
+        p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
+        p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
+        if (am_frame.precise)
+        {
+          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
+          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
+        }
+
+        if (V_GetMode() == VID_MODEGL ? 
+            p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
+            p.y < f_y + f_h && p.y >= f_y)
+        {
+          w = 0;
+          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
+          {
+            namebuf[6] = markpoints[i].label[k];
+
+            if (p.x < f_x + f_w &&
+                p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
+            {
+              if (am_frame.precise)
+              {
+                V_DrawNamePatchPrecise(
+                  (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+              }
+              else
+              {
+                V_DrawNamePatch(
+                  p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
+                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+              }
+            }
+
+            w += markpoints[i].widths[k] + 1;
+            p.x += w * SCREENWIDTH / 320;
+            if (am_frame.precise)
+            {
+              p.fx += (float)w * SCREENWIDTH / 320.0f;
+            }
           }
         }
       }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2117,138 +2117,98 @@ static void AM_drawMarks(void)
       else
         AM_SetMPointFloatValue(&p);
 
-      if (render_stretch_hud == 0)
+      p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
+      p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
+      if (am_frame.precise)
       {
-        p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
-        p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
-        if (am_frame.precise)
-        {
-          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
-          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
-        }
+        p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
+        p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
+      }
 
-        if (V_GetMode() == VID_MODEGL ? 
-            p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
-            p.y < f_y + f_h && p.y >= f_y)
+      if (V_GetMode() == VID_MODEGL ? 
+          p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
+          p.y < f_y + f_h && p.y >= f_y)
+      {
+        w = 0;
+        for (k = 0; k < (int)strlen(markpoints[i].label); k++)
         {
-          w = 0;
-          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
+          namebuf[6] = markpoints[i].label[k];
+
+          if (p.x < f_x + f_w &&
+              p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
           {
-            namebuf[6] = markpoints[i].label[k];
-
-            if (p.x < f_x + f_w &&
-                p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
+            switch (render_stretch_hud)
             {
-              if (am_frame.precise)
-              {
-                V_DrawNamePatchPrecise(
-                  (float)p.fx / patches_scalex, (float)p.fy * 200.0f / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-              }
-              else
-              {
-                V_DrawNamePatch(
-                  p.x / patches_scalex, p.y * 200 / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-              }
-            }
-
-            w += markpoints[i].widths[k] + 1;
-            p.x += w * patches_scalex;
-            if (am_frame.precise)
-            {
-              p.fx += (float)w * patches_scalex;
+              case patch_stretch_16x10:
+                if (am_frame.precise)
+                {
+                  V_DrawNamePatchPrecise(
+                    (float)p.fx / patches_scalex, (float)p.fy * 200.0f / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+                }
+                else
+                {
+                  V_DrawNamePatch(
+                    p.x / patches_scalex, p.y * 200 / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+                }
+                break;
+              case patch_stretch_4x3:
+                if (am_frame.precise)
+                {
+                  V_DrawNamePatchPrecise(
+                    (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+                }
+                else
+                {
+                  V_DrawNamePatch(
+                    p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+                }
+                break;
+              case patch_stretch_full:
+                if (am_frame.precise)
+                {
+                  V_DrawNamePatchPrecise(
+                    (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+                }
+                else
+                {
+                  V_DrawNamePatch(
+                    p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
+                    FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+                }
+                break;
             }
           }
-        }
-      }
-      else if (render_stretch_hud == 1)
-      {
-        p.x = CXMTOF(p.x) - markpoints[i].w * WIDE_SCREENWIDTH / 320 / 2;
-        p.y = CYMTOF(p.y) - markpoints[i].h * WIDE_SCREENHEIGHT / 200 / 2;
-        if (am_frame.precise)
-        {
-          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * WIDE_SCREENWIDTH / 320.0f / 2.0f;
-          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * WIDE_SCREENHEIGHT / 200.0f / 2.0f;
-        }
 
-        if (V_GetMode() == VID_MODEGL ? 
-            p.y < f_y + f_h && p.y + markpoints[i].h * WIDE_SCREENHEIGHT / 200 >= f_y :
-            p.y < f_y + f_h && p.y >= f_y)
-        {
-          w = 0;
-          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
+          w += markpoints[i].widths[k] + 1;
+
+          switch (render_stretch_hud)
           {
-            namebuf[6] = markpoints[i].label[k];
-
-            if (p.x < f_x + f_w &&
-                p.x + markpoints[i].widths[k] * WIDE_SCREENWIDTH / 320 >= f_x)
-            {
+            case patch_stretch_16x10:
+              p.x += w * patches_scalex;
               if (am_frame.precise)
               {
-                V_DrawNamePatchPrecise(
-                  (float)p.fx * 320.0f / WIDE_SCREENWIDTH, (float)p.fy * 200.0f / WIDE_SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
+                p.fx += (float)w * patches_scalex;
               }
-              else
-              {
-                V_DrawNamePatch(
-                  p.x * 320 / WIDE_SCREENWIDTH, p.y * 200 / WIDE_SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_LEFT | VPT_STRETCH);
-              }
-            }
-
-            w += markpoints[i].widths[k] + 1;
-            p.x += w * WIDE_SCREENWIDTH / 320;
-            if (am_frame.precise)
-            {
-              p.fx += (float)w * WIDE_SCREENWIDTH / 320.0f;
-            }
-          }
-        }
-      }
-      else if (render_stretch_hud == 2)
-      {
-        p.x = CXMTOF(p.x) - markpoints[i].w * SCREENWIDTH / 320 / 2;
-        p.y = CYMTOF(p.y) - markpoints[i].h * SCREENHEIGHT / 200 / 2;
-        if (am_frame.precise)
-        {
-          p.fx = CXMTOF_F(p.fx) - (float)markpoints[i].w * SCREENWIDTH / 320.0f / 2.0f;
-          p.fy = CYMTOF_F(p.fy) - (float)markpoints[i].h * SCREENHEIGHT / 200.0f / 2.0f;
-        }
-
-        if (V_GetMode() == VID_MODEGL ? 
-            p.y < f_y + f_h && p.y + markpoints[i].h * SCREENHEIGHT / 200 >= f_y :
-            p.y < f_y + f_h && p.y >= f_y)
-        {
-          w = 0;
-          for (k = 0; k < (int)strlen(markpoints[i].label); k++)
-          {
-            namebuf[6] = markpoints[i].label[k];
-
-            if (p.x < f_x + f_w &&
-                p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)
-            {
+              break;
+            case patch_stretch_4x3:
+              p.x += w * WIDE_SCREENWIDTH / 320;
               if (am_frame.precise)
               {
-                V_DrawNamePatchPrecise(
-                  (float)p.fx * 320.0f / SCREENWIDTH, (float)p.fy * 200.0f / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+                p.fx += (float)w * WIDE_SCREENWIDTH / 320.0f;
               }
-              else
+              break;
+            case patch_stretch_full:
+              p.x += w * SCREENWIDTH / 320;
+              if (am_frame.precise)
               {
-                V_DrawNamePatch(
-                  p.x * 320 / SCREENWIDTH, p.y * 200 / SCREENHEIGHT,
-                  FB, namebuf, CR_DEFAULT, VPT_ALIGN_WIDE | VPT_STRETCH);
+                p.fx += (float)w * SCREENWIDTH / 320.0f;
               }
-            }
-
-            w += markpoints[i].widths[k] + 1;
-            p.x += w * SCREENWIDTH / 320;
-            if (am_frame.precise)
-            {
-              p.fx += (float)w * SCREENWIDTH / 320.0f;
-            }
+              break;
           }
         }
       }


### PR DESCRIPTION
The drawn patch for the automap marker number always assumed `patch_stretch_full` as the stretch setting, so on `patch_stretch_16x10` or `patch_stretch_4x3` the marker position was not being set correctly. This should correct the behavior for opengl & software, all resolutions, aspect ratios, and stretch settings. Unfortunately I was unable to test every possibility, so there may still be unintended behavior.

Fixes #90