### PR TITLE
Fix sky walls for cases with sky vs. sky toptextures like E4M6.

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1747,7 +1747,7 @@ void gld_AddWall(seg_t *seg)
         }
         else
         {
-          if ((toptexture != NO_TEXTURE && midtexture == NO_TEXTURE) ||
+          if (((backsector->ceilingpic != skyflatnum && toptexture != NO_TEXTURE) && midtexture == NO_TEXTURE) ||
             backsector->ceilingpic != skyflatnum ||
             backsector->ceilingheight <= frontsector->floorheight)
           {


### PR DESCRIPTION
Proposed fix for #173.

I had some time to look into this bug, and it's simpler than I anticipated. The code I had planned to add is already there. The issue is that the code that adds depth buffer blocking sky walls is checking for height differences with upper textures but doesn't verify the upper texture would be applied to a sky sector. The Doom software renderer does not render upper textures against the sky. This PR checks that top textures applied to a sky sector do not affect the decision to generate blocking sky walls.