### PR TITLE
Fix transparent sprites in OpenGL mode

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1478,18 +1478,6 @@ void deh_changeCompTranslucency(void)
   {
     if (!DEH_mobjinfo_bits[predefined_translucency[i]])
     {
-      // Transparent sprites are not visible behind transparent walls in OpenGL.
-      // It needs much work.
-#ifdef GL_DOOM
-      if (V_GetMode() == VID_MODEGL)
-      {
-        // Disabling transparency in OpenGL for original sprites
-        // which are not changed by dehacked, because it's buggy for now.
-        // Global sorting of transparent sprites and walls is needed
-        mobjinfo[predefined_translucency[i]].flags &= ~MF_TRANSLUCENT;
-      }
-      else
-#endif
       if (comp[comp_translucency]) 
         mobjinfo[predefined_translucency[i]].flags &= ~MF_TRANSLUCENT;
       else 

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -253,6 +253,7 @@ typedef struct
   uint_64_t flags;
   int index;
   int xy;
+  fixed_t fx,fy;
 } GLSprite;
 
 typedef enum

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -2624,6 +2624,8 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
 
   sprite.index = gl_spriteindex++;
   sprite.xy = thing->x + (thing->y >> 16); 
+  sprite.fx = thing->x;
+  sprite.fy = thing->y;
 
   sprite.vt = 0.0f;
   sprite.vb = sprite.gltexture->scaleyfac;
@@ -3259,8 +3261,8 @@ void gld_DrawScene(player_t *player)
               int ti;
               for (ti = tsprite_idx; ti >= 0; ti--) {
                   /* reconstruct the sprite xy */
-                  fixed_t tsx = gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & ~(0x0000FFFF);
-                  fixed_t tsy = (gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & ~(0xFFFF0000)) << FRACBITS;
+                  fixed_t tsx = gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->fx;
+                  fixed_t tsy = gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->fy;
 
                   if (R_PointOnSegSide(tsx, tsy, twseg))
                   {

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -3246,7 +3246,6 @@ void gld_DrawScene(player_t *player)
       if (tsprite_idx > 0)
           gld_DrawItemsSortSprites(GLDIT_TSPRITE);
 
-      glDepthMask(GL_FALSE);
       while (twall_idx >= 0 || tsprite_idx >= 0 )
       {
           dboolean draw_tsprite = false;
@@ -3289,16 +3288,17 @@ void gld_DrawScene(player_t *player)
           }
           else
           {
+              glDepthMask(GL_FALSE);
               /* transparent wall is farther, draw it */
               glAlphaFunc(GL_GREATER, 0.0f);
               gld_SetFog(gld_drawinfo.items[GLDIT_TWALL][twall_idx].item.wall->fogdensity);
               gld_ProcessWall(gld_drawinfo.items[GLDIT_TWALL][twall_idx].item.wall);
+              glDepthMask(GL_TRUE);
               twall_idx--;
           }
       }
       glAlphaFunc(GL_GEQUAL, 0.5f);
       glEnable(GL_ALPHA_TEST);
-      glDepthMask(GL_TRUE);
   }
 
   // e6y: detail

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -3252,9 +3252,9 @@ void gld_DrawScene(player_t *player)
               fixed_t tsx = gld_drawinfo.items[GLDIT_TSPRITE][tsprite_idx].item.sprite->xy & 0xFFFF0000;
               fixed_t tsy = (gld_drawinfo.items[GLDIT_TSPRITE][tsprite_idx].item.sprite->xy & 0x0000FFFF) << 16;
 
-              if (R_PointOnSegSide(tsx, tsy, twseg))
+              if (!R_PointOnSegSide(tsx, tsy, twseg))
               {
-                  draw_tsprite = true;
+                  draw_tsprite = false;
               }
           }
           else if (twall_idx >= 0)

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -3259,8 +3259,8 @@ void gld_DrawScene(player_t *player)
               int ti;
               for (ti = tsprite_idx; ti >= 0; ti--) {
                   /* reconstruct the sprite xy */
-                  fixed_t tsx = gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & 0xFFFF0000;
-                  fixed_t tsy = (gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & 0x0000FFFF) << 16;
+                  fixed_t tsx = gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & ~(0x0000FFFF);
+                  fixed_t tsy = (gld_drawinfo.items[GLDIT_TSPRITE][ti].item.sprite->xy & ~(0xFFFF0000)) << FRACBITS;
 
                   if (R_PointOnSegSide(tsx, tsy, twseg))
                   {
@@ -3273,10 +3273,10 @@ void gld_DrawScene(player_t *player)
           }
           else if (tsprite_idx >= 0)
           {
-              /* no transparent sprites left, draw a wall */
+              /* no transparent walls left, draw a sprite */
               draw_tsprite = true;
           }
-          /* fall-through case is draw seg */
+          /* fall-through case is draw wall */
 
           if (draw_tsprite)
           {


### PR DESCRIPTION
Proposed fix for #112.

I would like to open the discussion on resolving transparent sprites and walls.

The old PrBoom renderer placed all draw items into a single array and sorted them by distance. This method had many drawbacks. PrBoom+ splits the render items up according to type, which is much cleaner, but introduces a problem for transparent items in differing categories.

Sorting the two simultaneously is a fairly big effort, I think. There is a much simpler approach of determining which element is farther and rendering that one first. This is almost an "in-place sort" by popping items off the tail of the array and comparing them.

There is a bit of awkward code needed to unpack the x/y coordinates of the GLSprite's original Thing. The coordinates are packed into an integer, presumably to simplify sorting, and must be unpacked to check which seg side the original Thing is on when comparing a transparent wall (seg) vs. a transparent Thing.

I think the speedup from merging and sorting the transparent items in the same array would not be so great as it only saves the unpack and comparison operations during the render stages.