### PR TITLE
Fix sky scaling for non-standard sky sizes.

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -159,12 +159,12 @@ void gld_GetScreenSkyScale(GLWall *wall, float *scale_x, float *scale_y)
   if (!mlook_or_fov)
   {
     sx = sx / (float)wall->gltexture->buffer_width;
-    sy = 200.0f / 160.0f;//wall->gltexture->buffer_height;
+    sy = 200.0f / (wall->gltexture->buffer_height * 1.25f);
   }
   else 
   {
     sx = sx * skyscale / (float)wall->gltexture->buffer_width;
-    sy = 127.0f * skyscale / 160.0f;
+    sy = 127.0f * skyscale / (wall->gltexture->buffer_height * 1.25f);
   }
 
   *scale_x = sx;


### PR DESCRIPTION
Proposed fix for #206.

When rendering a the sky as a dome in OpenGL rendering mode, the y-scaling is calculated based on a fixed factor of 200/160. This change would take the sky texture's vertical size into account.

From my local testing it resolves the issues with non-standard sky sizes such as Eviternity and Ancient Aliens.