### PR TITLE
Fix for UMAPINFO music restarting issue.

### DIFF
--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -64,11 +64,22 @@ void S_ParseMusInfo(const char *mapid)
   {
     int num, lumpnum;
     int inMap = false;
+    int load_muslump = -1;
+    /* musinfo item zero is initialized
+     * before we reach the parser and it must be
+     * saved and restored */
+    int itemzero = musinfo.items[0];
+
+    /* don't restart music that is already playing */
+    if (mus_playing &&
+        mus_playing->lumpnum == S_music[NUMMUSIC].lumpnum) {
+        load_muslump = S_music[NUMMUSIC].lumpnum;
+    }
 
     memset(&musinfo, 0, sizeof(musinfo));
-    musinfo.current_item = -1;
-
-    S_music[NUMMUSIC].lumpnum = -1;
+    musinfo.items[0] = itemzero;
+    musinfo.current_item = load_muslump;
+    S_music[NUMMUSIC].lumpnum = load_muslump;
 
     SC_OpenLump("MUSINFO");
 

--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -59,15 +59,16 @@ musinfo_t musinfo;
 //
 void S_ParseMusInfo(const char *mapid)
 {
-  memset(&musinfo, 0, sizeof(musinfo));
-  musinfo.current_item = -1;
-
-  S_music[NUMMUSIC].lumpnum = -1;
 
   if (W_CheckNumForName("MUSINFO") != -1)
   {
     int num, lumpnum;
     int inMap = false;
+
+    memset(&musinfo, 0, sizeof(musinfo));
+    musinfo.current_item = -1;
+
+    S_music[NUMMUSIC].lumpnum = -1;
 
     SC_OpenLump("MUSINFO");
 

--- a/prboom2/src/s_advsound.h
+++ b/prboom2/src/s_advsound.h
@@ -35,6 +35,7 @@
 #define __S_ADVSOUND__
 
 #include "p_mobj.h"
+#include "sounds.h"
 
 #ifdef __GNUG__
 #pragma interface
@@ -55,6 +56,7 @@ typedef struct musinfo_s
   int items[MAX_MUS_ENTRIES];
 } musinfo_t;
 
+extern musicinfo_t *mus_playing;
 extern musinfo_t musinfo;
 
 void S_ParseMusInfo(const char *mapid);

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -533,6 +533,7 @@ void S_ChangeMusic(int musicnum, int looping)
   // current music which should play
   musicnum_current = musicnum;
   musinfo.current_item = -1;
+  S_music[NUMMUSIC].lumpnum = -1;
 
   //jff 1/22/98 return if music is not enabled
   if (!mus_card || nomusicparm)

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -95,7 +95,7 @@ int snd_MusicVolume = 15;
 static dboolean mus_paused;
 
 // music currently being played
-static musicinfo_t *mus_playing;
+musicinfo_t *mus_playing;
 
 // music currently should play
 static int musicnum_current;
@@ -207,6 +207,7 @@ void S_Start(void)
 	  int muslump = W_CheckNumForName(gamemapinfo->music);
 	  if (muslump >= 0)
 	  {
+		  musinfo.items[0] = muslump;
 		  S_ChangeMusInfoMusic(muslump, true);
 		  return;
 	  }


### PR DESCRIPTION
Proposed fix for #279, #102.

Background information on why this issue happens:

1. `S_ParseMusInfo` wipes out the `musinfo` structure, presuming it will not be used if a `MUSINFO` lump is not present. But since the `UMAPINFO` code re-uses the `musinfo` structure, it should not be wiped out.
2. `S_ChangeMusic` doesn't reset the entries in `S_music` that might be in use by `MUSINFO`. Presumably the parsing took care of this previously. I believe this to be an oversight, but others may be able to say more.

This PR does two things:

1. In `S_ParseMusInfo`, only wipe out the `musinfo` structure if a `MUSINFO` lump is present.
2. `S_ChangeMusic` cleans up `S_music`.

Feedback as always is welcome.