### PR TITLE
skip the 'entering level' screen if one of endgame, endpic, endbunny …

### DIFF
--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -65,17 +65,19 @@ partime = seconds
 endgame = false
 
 ; Ends the game after this level, showing the default post-game screen for the
-; current episode.
+; current episode. Skips the 'entering level' screen.
 endgame = true
 
 ; Ends the game after this level, showing the specified graphic as an end
-; screen.
+; screen. Skips the 'entering level' screen.
 endpic = "graphic"
 
-; Ends the game after this level, showing the bunny scroller.
+; Ends the game after this level, showing the bunny scroller. Skips the
+; 'entering level' screen.
 endbunny = true
 
-; Ends the game after this level, showing the cast call.
+; Ends the game after this level, showing the cast call. Skips the 'entering
+; level' screen.
 endcast = true
 
 ; Currently only working for levels that end the game: When true skips the
@@ -310,6 +312,10 @@ Thingtypes:
 
 
 Revisions:
+
+Rev 1.5 (@fabiangreffrath, Apr 19 2021)
+ * Skip the 'entering level' screen if one of endgame, endpic, endbunny or
+   endcast is set.
 
 Rev 1.4 (@rfomin, Mar 23 2021)
  * Clarify the 'episode' field in the case of Doom 2 and Chex Quest.

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -1073,6 +1073,13 @@ void WI_drawShowNextLoc(void)
       WI_drawOnLnode(wbs->next, yah);
   }
 
+  if (gamemapinfo != NULL &&
+      gamemapinfo->endpic[0] &&
+      strcmp(gamemapinfo->endpic, "-") != 0)
+  {
+    return;
+  }
+
   if (gamemission == pack_nerve && singleplayer && wbs->last == 7)
     return; // MAP08 end game
 


### PR DESCRIPTION
…or endcast is set

Fixes #263