### PR TITLE
Reset mlook on recording

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3548,6 +3548,9 @@ void G_BeginRecording (void)
 
   if (fwrite(demostart, 1, demo_p-demostart, demofp) != (size_t)(demo_p-demostart))
     I_Error("G_BeginRecording: Error writing demo header");
+
+  R_DemoEx_ResetMLook();
+
   free(demostart);
 }
 

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -450,6 +450,11 @@ angle_t R_DemoEx_ReadMLook(void)
   return (pitch << 16);
 }
 
+void R_DemoEx_ResetMLook(void)
+{
+  mlook_lump.tick = 0;
+}
+
 void R_DemoEx_WriteMLook(angle_t pitch)
 {
   if (!use_demoex_info || !demorecording)

--- a/prboom2/src/r_demo.h
+++ b/prboom2/src/r_demo.h
@@ -116,6 +116,7 @@ void W_AddLump(wadtbl_t *wadtbl, const char *name, const byte* data, size_t size
 extern dboolean use_demoex_info;
 void R_DemoEx_WriteMLook(angle_t pitch);
 angle_t R_DemoEx_ReadMLook(void);
+void R_DemoEx_ResetMLook(void);
 
 dboolean D_TryGetWad(const char* name);
 


### PR DESCRIPTION
In pr+, mouselook information is tracked over the course of a demo recording and then appended to the bottom of a demo if it is nonzero for any tick. That tracking doesn't know about demo restarts though, so the buffer fills indefinitely in long recording sessions - and the whole buffer is put into the demo footer when the player exits. So, a demo will contain bad mouselook info when using the restart feature, if mouselook is nonzero for any tick of any demo attempt.

This PR resets the mouselook tick to 0 when beginning a recording, so that it stays consistent with the demo state.

Note that the mouselook data is tracked even if mouselook is on, since it can be turned on or off in the middle of a demo, so the mouselook buffer does affect all users, regardless of whether or not mouselook is turned on.