### PR TITLE
Add OpenGL sprite fuzz options.

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -156,6 +156,23 @@ GLfloat cm2RGB[CR_LIMIT + 1][4] =
   {1.00f ,1.00f, 1.00f, 1.00f}, //CR_LIMIT
 };
 
+static void gld_SetSpriteFuzzBlendFunc(spritefuzzmode_t fuzzmode)
+{
+    switch (fuzzmode)
+    {
+        default:
+        case fuzz_darken:
+            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        case fuzz_shadow:
+            glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        case fuzz_transparent:
+            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+    }
+}
+
 void SetFrameTextureMode(void)
 {
 #ifdef USE_FBO_TECHNIQUE
@@ -892,19 +909,7 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // when invisibility is about to go
   if (/*(viewplayer->mo->flags & MF_SHADOW) && */!vis->colormap)
   {
-    switch (gl_weaponspritefuzzmode)
-    {
-        default:
-        case fuzz_darken:
-            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-        case fuzz_shadow:
-            glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-        case fuzz_transparent:
-            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-    }
+    gld_SetSpriteFuzzBlendFunc(gl_weaponspritefuzzmode);
     glAlphaFunc(GL_GEQUAL,0.1f);
     //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
     glColor4f(0.2f,0.2f,0.2f,0.33f);
@@ -2268,19 +2273,7 @@ static void gld_DrawSprite(GLSprite *sprite)
     {
       glGetIntegerv(GL_BLEND_SRC, &blend_src);
       glGetIntegerv(GL_BLEND_DST, &blend_dst);
-      switch (gl_thingspritefuzzmode)
-      {
-          default:
-          case fuzz_darken:
-              glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
-              break;
-          case fuzz_shadow:
-              glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
-              break;
-          case fuzz_transparent:
-              glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-              break;
-      }
+      gld_SetSpriteFuzzBlendFunc(gl_thingspritefuzzmode);
       //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
       glAlphaFunc(GL_GEQUAL,0.1f);
       glColor4f(0.2f,0.2f,0.2f,0.33f);

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -894,6 +894,7 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   {
     switch (gl_weaponspritefuzzmode)
     {
+        default:
         case fuzz_darken:
             glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
             break;
@@ -902,11 +903,6 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
             break;
         case fuzz_transparent:
             glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-        default:
-            /* default back to PrBoom original mode */
-            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
-            lprintf(LO_WARN,"Invalid weapon sprite fuzz mode %d.\n", gl_weaponspritefuzzmode);
             break;
     }
     glAlphaFunc(GL_GEQUAL,0.1f);
@@ -2274,6 +2270,7 @@ static void gld_DrawSprite(GLSprite *sprite)
       glGetIntegerv(GL_BLEND_DST, &blend_dst);
       switch (gl_thingspritefuzzmode)
       {
+          default:
           case fuzz_darken:
               glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
               break;
@@ -2282,11 +2279,6 @@ static void gld_DrawSprite(GLSprite *sprite)
               break;
           case fuzz_transparent:
               glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-              break;
-          default:
-              /* default back to PrBoom original mode */
-              glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
-              lprintf(LO_WARN,"Invalid thing sprite fuzz mode %d.\n", gl_thingspritefuzzmode);
               break;
       }
       //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -127,6 +127,9 @@ float gl_sprite_offset;       // precalcilated float value for gl_sprite_offset_
 int gl_sprite_blend;  // e6y: smooth sprite edges
 int gl_mask_sprite_threshold;
 float gl_mask_sprite_threshold_f;
+spritefuzzmode_t gl_thingspritefuzzmode;
+spritefuzzmode_t gl_weaponspritefuzzmode;
+const char *gl_spritefuzzmodes[] = {"darken", "shadow", "transparent"};
 
 GLuint gld_DisplayList=0;
 int fog_density=200;
@@ -889,7 +892,23 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // when invisibility is about to go
   if (/*(viewplayer->mo->flags & MF_SHADOW) && */!vis->colormap)
   {
-    glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+    switch (gl_weaponspritefuzzmode)
+    {
+        case fuzz_darken:
+            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        case fuzz_shadow:
+            glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        case fuzz_transparent:
+            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+            break;
+        default:
+            /* default back to PrBoom original mode */
+            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+            lprintf(LO_WARN,"Invalid weapon sprite fuzz mode %d.\n", gl_weaponspritefuzzmode);
+            break;
+    }
     glAlphaFunc(GL_GEQUAL,0.1f);
     //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
     glColor4f(0.2f,0.2f,0.2f,0.33f);
@@ -2253,7 +2272,23 @@ static void gld_DrawSprite(GLSprite *sprite)
     {
       glGetIntegerv(GL_BLEND_SRC, &blend_src);
       glGetIntegerv(GL_BLEND_DST, &blend_dst);
-      glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+      switch (gl_thingspritefuzzmode)
+      {
+          case fuzz_darken:
+              glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+              break;
+          case fuzz_shadow:
+              glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+              break;
+          case fuzz_transparent:
+              glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+              break;
+          default:
+              /* default back to PrBoom original mode */
+              glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
+              lprintf(LO_WARN,"Invalid thing sprite fuzz mode %d.\n", gl_thingspritefuzzmode);
+              break;
+      }
       //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
       glAlphaFunc(GL_GEQUAL,0.1f);
       glColor4f(0.2f,0.2f,0.2f,0.33f);

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -127,9 +127,14 @@ float gl_sprite_offset;       // precalcilated float value for gl_sprite_offset_
 int gl_sprite_blend;  // e6y: smooth sprite edges
 int gl_mask_sprite_threshold;
 float gl_mask_sprite_threshold_f;
+/* Note: These must be identically-indexed,
+ * including the spritefuzzmode enum */
 spritefuzzmode_t gl_thingspritefuzzmode;
 spritefuzzmode_t gl_weaponspritefuzzmode;
-const char *gl_spritefuzzmodes[] = {"darken", "shadow", "transparent"};
+const char *gl_spritefuzzmodes[] = {"darken", "shadow", "transparent", "ghostly"};
+GLenum gl_fuzzsfactors[] = {GL_DST_COLOR, GL_ZERO, GL_ONE, GL_SRC_ALPHA};
+GLenum gl_fuzzdfactors[] = {GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA,
+    GL_ONE_MINUS_SRC_ALPHA, GL_ONE};
 
 GLuint gld_DisplayList=0;
 int fog_density=200;
@@ -156,22 +161,6 @@ GLfloat cm2RGB[CR_LIMIT + 1][4] =
   {1.00f ,1.00f, 1.00f, 1.00f}, //CR_LIMIT
 };
 
-static void gld_SetSpriteFuzzBlendFunc(spritefuzzmode_t fuzzmode)
-{
-    switch (fuzzmode)
-    {
-        default:
-        case fuzz_darken:
-            glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-        case fuzz_shadow:
-            glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-        case fuzz_transparent:
-            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-            break;
-    }
-}
 
 void SetFrameTextureMode(void)
 {
@@ -909,7 +898,8 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // when invisibility is about to go
   if (/*(viewplayer->mo->flags & MF_SHADOW) && */!vis->colormap)
   {
-    gld_SetSpriteFuzzBlendFunc(gl_weaponspritefuzzmode);
+    glBlendFunc(gl_fuzzsfactors[gl_weaponspritefuzzmode],
+            gl_fuzzdfactors[gl_weaponspritefuzzmode]);
     glAlphaFunc(GL_GEQUAL,0.1f);
     //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
     glColor4f(0.2f,0.2f,0.2f,0.33f);
@@ -2273,7 +2263,8 @@ static void gld_DrawSprite(GLSprite *sprite)
     {
       glGetIntegerv(GL_BLEND_SRC, &blend_src);
       glGetIntegerv(GL_BLEND_DST, &blend_dst);
-      gld_SetSpriteFuzzBlendFunc(gl_thingspritefuzzmode);
+      glBlendFunc(gl_fuzzsfactors[gl_thingspritefuzzmode],
+            gl_fuzzdfactors[gl_thingspritefuzzmode]);
       //glColor4f(0.2f,0.2f,0.2f,(float)tran_filter_pct/100.0f);
       glAlphaFunc(GL_GEQUAL,0.1f);
       glColor4f(0.2f,0.2f,0.2f,0.33f);

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -205,7 +205,7 @@ void gld_DrawMapLines(void);
 
 //sprites
 typedef enum { spriteclip_const, spriteclip_always, spriteclip_smart } spriteclipmode_t;
-typedef enum { fuzz_darken, fuzz_shadow, fuzz_transparent, fuzz_last } spritefuzzmode_t;
+typedef enum { fuzz_darken, fuzz_shadow, fuzz_transparent, fuzz_ghostly, fuzz_last } spritefuzzmode_t;
 extern spritefuzzmode_t gl_thingspritefuzzmode;
 extern spritefuzzmode_t gl_weaponspritefuzzmode;
 extern const char *gl_spritefuzzmodes[];

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -205,6 +205,10 @@ void gld_DrawMapLines(void);
 
 //sprites
 typedef enum { spriteclip_const, spriteclip_always, spriteclip_smart } spriteclipmode_t;
+typedef enum { fuzz_darken, fuzz_shadow, fuzz_transparent, fuzz_last } spritefuzzmode_t;
+extern spritefuzzmode_t gl_thingspritefuzzmode;
+extern spritefuzzmode_t gl_weaponspritefuzzmode;
+extern const char *gl_spritefuzzmodes[];
 extern spriteclipmode_t gl_spriteclip;
 extern const char *gl_spriteclipmodes[];
 extern int gl_spriteclip_threshold;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3423,12 +3423,14 @@ setup_menu_t gen_settings5[] = { // General Settings screen3
   {"Sector Light Mode",         S_CHOICE, m_null, G_X, G_Y+ 8*8, {"gl_lightmode"}, 0, 0, M_ChangeLightMode, gl_lightmodes},
   {"Allow Fog",                 S_YESNO,  m_null, G_X, G_Y+ 9*8, {"gl_fog"}, 0, 0, M_ChangeAllowFog},
   {"Simple Shadows",            S_YESNO,  m_null, G_X, G_Y+10*8, {"gl_shadows"}},
+  {"Thing Sprite Fuzz",         S_CHOICE, m_null, G_X, G_Y+11*8, {"gl_thingspritefuzzmode"}, 0, 0, 0, gl_spritefuzzmodes},
+  {"Weapon Sprite Fuzz",        S_CHOICE, m_null, G_X, G_Y+12*8, {"gl_weaponspritefuzzmode"}, 0, 0, 0, gl_spritefuzzmodes},
 
-  {"Paper Items",               S_YESNO,  m_null, G_X, G_Y+12*8, {"render_paperitems"}},
-  {"Smooth sprite edges",       S_YESNO,  m_null, G_X, G_Y+13*8, {"gl_sprite_blend"}},
-  {"Adjust Sprite Clipping",    S_CHOICE, m_null, G_X, G_Y+14*8, {"gl_spriteclip"}, 0, 0, M_ChangeSpriteClip, gl_spriteclipmodes},
-  {"Item out of Floor offset",  S_NUM,    m_null, G_X, G_Y+15*8, {"gl_sprite_offset"}, 0, 0, M_ChangeSpriteClip},
-  {"Health Bar Above Monsters", S_YESNO,  m_null, G_X, G_Y+16*8, {"health_bar"}},
+  {"Paper Items",               S_YESNO,  m_null, G_X, G_Y+13*8, {"render_paperitems"}},
+  {"Smooth sprite edges",       S_YESNO,  m_null, G_X, G_Y+14*8, {"gl_sprite_blend"}},
+  {"Adjust Sprite Clipping",    S_CHOICE, m_null, G_X, G_Y+15*8, {"gl_spriteclip"}, 0, 0, M_ChangeSpriteClip, gl_spriteclipmodes},
+  {"Item out of Floor offset",  S_NUM,    m_null, G_X, G_Y+16*8, {"gl_sprite_offset"}, 0, 0, M_ChangeSpriteClip},
+  {"Health Bar Above Monsters", S_YESNO,  m_null, G_X, G_Y+17*8, {"health_bar"}},
 #endif
 
   {"<- PREV",S_SKIP|S_PREV, m_null,KB_PREV, KB_Y+20*8, {gen_settings4}},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -268,6 +268,8 @@ simple_shadow_params_t simple_shadows;
 int gl_shadows_maxdist;
 int gl_shadows_factor;
 int gl_blend_animations;
+spritefuzzmode_t gl_thingspritefuzzmode;
+spritefuzzmode_t gl_weaponspritefuzzmode;
 
 #endif
 
@@ -1174,6 +1176,10 @@ default_t defaults[] =
    def_int,ss_none},
   {"gl_blend_animations",{&gl_blend_animations},{0},0,1,
    def_bool,ss_none},
+  {"gl_thingspritefuzzmode",{(int*)&gl_thingspritefuzzmode},{fuzz_darken},fuzz_darken,fuzz_last-1,
+      def_int, ss_none},
+  {"gl_weaponspritefuzzmode",{(int*)&gl_weaponspritefuzzmode},{fuzz_darken},fuzz_darken,fuzz_last-1,
+      def_int, ss_none},
 
   {"Prboom-plus emulation settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"overrun_spechit_warn", {&overflows[OVERFLOW_SPECHIT].warn},  {0},0,1,


### PR DESCRIPTION
PR as requested for #288.

Adds three sprite fuzzing (partial invisibility) options, split for player's weapons and things (monsters, etc.):

1. Darken (default): This is the default PrBoom effect which darkens the source sprite and makes it transparent.
2. Shadow: Draw a shadow where the sprite would be, similar to the vanilla fuzz effect without the noise patterns.
3. Transparent: Draw a transparent version of the sprite.

