### PR TITLE
fix switching weapons when reaching zero ammo with boom_autoswitch == 0

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -579,7 +579,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   // Make Boom insert only a single weapon change command on autoswitch.
   if ((!demo_compatibility && players[consoleplayer].attackdown && // killough
-       !P_CheckAmmo(&players[consoleplayer]) && !done_autoswitch && boom_autoswitch) ||
+       !P_CheckAmmo(&players[consoleplayer]) && (!boom_autoswitch || !done_autoswitch)) ||
        gamekeydown[key_weapontoggle])
   {
     newweapon = P_SwitchWeapon(&players[consoleplayer]);           // phares

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -579,7 +579,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   // Make Boom insert only a single weapon change command on autoswitch.
   if ((!demo_compatibility && players[consoleplayer].attackdown && // killough
-       !P_CheckAmmo(&players[consoleplayer]) && (!boom_autoswitch || !done_autoswitch)) ||
+       !P_CheckAmmo(&players[consoleplayer]) && !(done_autoswitch && boom_autoswitch)) ||
        gamekeydown[key_weapontoggle])
   {
     newweapon = P_SwitchWeapon(&players[consoleplayer]);           // phares


### PR DESCRIPTION
This attempts to restore original Boom behavior when `boom_autoswitch`
is disabled and checks for `done_autoswitch` only if it is enabled.

Fixes #303