### PR TITLE
UMAPINFO: introduce the new 'label' field

### DIFF
--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -31,6 +31,14 @@ will be used, unless the following list says differently.
 ; the automap and also on the status screen if no name patch is specified.
 levelname = "name"
 
+; Specifies the string to prepend to the levelname on the automap. If not
+; specified the mapname will be used by default followed by a colon and a
+; space character (e.g. "E1M1: ").
+label = "name"
+
+; Only print the levelname on the automap.
+label = clear
+
 ; Specifies the patch that is used on the status screen for 'entering' and
 ; 'finished'. This can be omitted, in that case the levelname will be printed
 ; with the HUD font.
@@ -316,6 +324,10 @@ Thingtypes:
 
 
 Revisions:
+
+Rev 2 (@fabiangreffrath, May 11 2021)
+ * Introduce the new 'label' field to allow for overriding of the string that
+   gets prepended to the 'levelname' on the automap.
 
 Rev 1.6 (@fabiangreffrath, Apr 19 2021)
  * Skip the 'entering level' screen if one of endgame, endpic, endbunny or

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -739,12 +739,18 @@ void HU_Start(void)
 
   if (gamemapinfo != NULL)
   {
-	  s = gamemapinfo->mapname;
-	  while (*s)
-		  HUlib_addCharToTextLine(&w_title, *(s++));
+	  if (gamemapinfo->label)
+		  s = gamemapinfo->label;
+	  else
+		  s = gamemapinfo->mapname;
+	  if (s == gamemapinfo->mapname || strcmp(s, "-") != 0)
+	  {
+		  while (*s)
+			  HUlib_addCharToTextLine(&w_title, *(s++));
 
-	  HUlib_addCharToTextLine(&w_title, ':');
-	  HUlib_addCharToTextLine(&w_title, ' ');
+		  HUlib_addCharToTextLine(&w_title, ':');
+		  HUlib_addCharToTextLine(&w_title, ' ');
+	  }
 	  s = gamemapinfo->levelname;
 	  if (!s) s = "Unnamed";
 	  while (*s)

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -311,6 +311,7 @@ static void FreeMap(MapEntry *mape)
 {
 	if (mape->mapname) free(mape->mapname);
 	if (mape->levelname) free(mape->levelname);
+	if (mape->label) free(mape->label);
 	if (mape->intertext) free(mape->intertext);
 	if (mape->intertextsecret) free(mape->intertextsecret);
 	if (mape->properties) free(mape->properties);
@@ -419,6 +420,13 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 	{
 		scanner.MustGetToken(TK_StringConst);
 		ReplaceString(&mape->levelname, scanner.string);
+	}
+	else if (!stricmp(pname, "label"))
+	{
+		char *lname = ParseMultiString(scanner, 1);
+		if (!lname) return 0;
+		if (mape->label != NULL) free(mape->label);
+		mape->label = lname;
 	}
 	else if (!stricmp(pname, "next"))
 	{

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -426,6 +426,7 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 		char *lname = ParseMultiString(scanner, 1);
 		if (!lname) return 0;
 		if (mape->label != NULL) free(mape->label);
+		// TODO: require label to be single-line
 		mape->label = lname;
 	}
 	else if (!stricmp(pname, "next"))

--- a/prboom2/src/umapinfo.h
+++ b/prboom2/src/umapinfo.h
@@ -36,6 +36,7 @@ struct MapEntry
 {
 	char *mapname;
 	char *levelname;
+	char *label;
 	char *intertext;
 	char *intertextsecret;
 	char levelpic[9];


### PR DESCRIPTION
This allows for overriding of the string that gets prepended to the
'levelname' on the automap.

Fixes #294