### PR TITLE
Do not cast degenmobj_t as mobj_t, breaks some aliasing rules.

### DIFF
--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -116,7 +116,7 @@ int idmusnum;
 void S_StopChannel(int cnum);
 
 // Will start a sound at a given volume.
-void S_StartSoundAtVolume(degenmobj_t *origin, int sound_id, int volume);
+static void S_StartSoundAtVolume(degenmobj_t *origin, int sound_id, int volume);
 
 int S_AdjustSoundParams(mobj_t *listener, degenmobj_t *source,
                         int *vol, int *sep, int *pitch);
@@ -255,7 +255,7 @@ void S_Start(void)
   S_ChangeMusic(mnum, true);
 }
 
-void S_StartSoundAtVolume(degenmobj_t *origin, int sfx_id, int volume)
+static void S_StartSoundAtVolume(degenmobj_t *origin, int sfx_id, int volume)
 {
   int sep, pitch, priority, cnum, is_pickup;
   sfxinfo_t *sfx;

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -115,7 +115,10 @@ int idmusnum;
 
 void S_StopChannel(int cnum);
 
-int S_AdjustSoundParams(mobj_t *listener, mobj_t *source,
+// Will start a sound at a given volume.
+void S_StartSoundAtVolume(degenmobj_t *origin, int sound_id, int volume);
+
+int S_AdjustSoundParams(mobj_t *listener, degenmobj_t *source,
                         int *vol, int *sep, int *pitch);
 
 static int S_getChannel(void *origin, sfxinfo_t *sfxinfo, int is_pickup);
@@ -252,11 +255,10 @@ void S_Start(void)
   S_ChangeMusic(mnum, true);
 }
 
-void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)
+void S_StartSoundAtVolume(degenmobj_t *origin, int sfx_id, int volume)
 {
   int sep, pitch, priority, cnum, is_pickup;
   sfxinfo_t *sfx;
-  mobj_t *origin = (mobj_t *) origin_p;
 
   //jff 1/22/98 return if sound is not enabled
   if (!snd_card || nosfxparm)
@@ -296,7 +298,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)
   // Check to see if it is audible, modify the params
   // killough 3/7/98, 4/25/98: code rearranged slightly
 
-  if (!origin || (origin == players[displayplayer].mo && walkcamera.type < 2)) {
+  if (!origin || (origin == (degenmobj_t*)players[displayplayer].mo && walkcamera.type < 2)) {
     sep = NORM_SEP;
     volume *= 8;
   } else
@@ -710,7 +712,7 @@ void S_StopChannel(int cnum)
 // Otherwise, modifies parameters and returns 1.
 //
 
-int S_AdjustSoundParams(mobj_t *listener, mobj_t *source,
+int S_AdjustSoundParams(mobj_t *listener, degenmobj_t *source,
                         int *vol, int *sep, int *pitch)
 {
   fixed_t adx, ady,approx_dist;

--- a/prboom2/src/s_sound.h
+++ b/prboom2/src/s_sound.h
@@ -61,9 +61,6 @@ void S_Start(void);
 //
 void S_StartSound(void *origin, int sound_id);
 
-// Will start a sound at a given volume.
-void S_StartSoundAtVolume(void *origin, int sound_id, int volume);
-
 // killough 4/25/98: mask used to indicate sound origin is player item pickup
 #define PICKUP_SOUND (0x8000)
 


### PR DESCRIPTION
This is an issue on some platforms where gcc can assume that mobj_t
pointers are 64 bit aligned (due to `flags` being a 64 bit int) and
degenmobj_t pointers being only 32 bit aligned.
In said platforms gcc will do optimizations that result in mis-aligned
memory loads, which may or may not work.

Can provide more info on this, but it breaks builds on MIPS64 CPUs.

Lemme know if you need more context or have further questions, happy to help!