### PR TITLE
Fix solo net for demo restart

### DIFF
--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -82,6 +82,7 @@ int maketic;
 int ticdup = 1;
 static int xtratics = 0;
 int              wanted_player_number;
+int solo_net = 0;
 
 static void D_QuitNetGame (void);
 
@@ -103,7 +104,8 @@ void D_InitNetGame (void)
     // e6y
     // for play, recording or playback using "single-player coop" mode.
     // Equivalent to using prboom_server with -N 1
-    netgame = M_CheckParm("-solo-net");
+    solo_net = (M_CheckParm("-solo-net") != 0);
+    netgame = solo_net;
   } else {
     // Get game info from server
     packet_header_t *packet = Z_Malloc(1000, PU_STATIC, NULL);
@@ -170,7 +172,8 @@ void D_InitNetGame (void)
   doomcom->consoleplayer = 0;
   doomcom->numnodes = 0; doomcom->numplayers = 1;
   localcmds = netcmds[consoleplayer];
-  netgame = (M_CheckParm("-solo-net") != 0);
+  solo_net = (M_CheckParm("-solo-net") != 0);
+  netgame = solo_net;
 
   for (i=0; i<doomcom->numplayers; i++)
     playeringame[i] = true;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2758,11 +2758,13 @@ void G_ReloadDefaults(void)
 
 void G_DoNewGame (void)
 {
+  extern int solo_net;
+
   // e6y: allow new level's music to be loaded
   idmusnum = -1;
 
   G_ReloadDefaults();            // killough 3/1/98
-  netgame = false;               // killough 3/29/98
+  netgame = solo_net;
   deathmatch = false;
   G_InitNew (d_skill, d_episode, d_map);
   gameaction = ga_nothing;


### PR DESCRIPTION
The solo net information disappears when using the demo restart key. This PR just adds a solo_net variable to remember whether it's on or not, and applies that when restarting.