### PR TITLE
UMAPINFO: fix 'episode' field parsing, 'label' is single-line

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -566,7 +566,12 @@ short EpiMenuMap[8] = { 1, 1, 1, 1, -1, -1, -1, -1 }, EpiMenuEpi[8] = { 1,2,3,4,
 //
 int epiChoice;
 
-void M_AddEpisode(const char *map, char *def)
+void M_ClearEpisodes(void)
+{
+	EpiDef.numitems = 0;
+}
+
+void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha)
 {
 	if (!EpiCustom)
 	{
@@ -577,23 +582,15 @@ void M_AddEpisode(const char *map, char *def)
 			EpiDef.numitems = 0;
 	}
 
-	if (*def == '-')	// means 'clear'
-	{
-		EpiDef.numitems = 0;
-	}
-	else
 	{
 		int epi, mapnum;
-		const char *gfx = strtok(def, "\n");
-		const char *txt = strtok(NULL, "\n");
-		const char *alpha = strtok(NULL, "\n");
 		if (EpiDef.numitems >= 8) return;
 		G_ValidateMapName(map, &epi, &mapnum);
 		EpiMenuEpi[EpiDef.numitems] = epi;
 		EpiMenuMap[EpiDef.numitems] = mapnum;
 		strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
 		EpisodeMenu[EpiDef.numitems].name[8] = 0;
-		EpisodeMenu[EpiDef.numitems].alttext = txt;
+		EpisodeMenu[EpiDef.numitems].alttext = txt ? strdup(txt) : NULL;
 		EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
 		EpiDef.numitems++;
 	}

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -31,7 +31,8 @@ extern "C"
 #include "doomdef.h"
 #include "doomstat.h"
 
-void M_AddEpisode(const char *map, char *def);
+void M_AddEpisode(const char *map, const char *gfx, const char *txt, const char *alpha);
+void M_ClearEpisodes(void);
 
 MapList Maps;
 }
@@ -423,11 +424,20 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 	}
 	else if (!stricmp(pname, "label"))
 	{
-		char *lname = ParseMultiString(scanner, 1);
-		if (!lname) return 0;
-		if (mape->label != NULL) free(mape->label);
-		// TODO: require label to be single-line
-		mape->label = lname;
+		if (scanner.CheckToken(TK_Identifier))
+		{
+			if (!stricmp(scanner.string, "clear")) ReplaceString(&mape->label, "-");
+			else
+			{
+				scanner.ErrorF("Either 'clear' or string constant expected");
+				return 0;
+			}
+		}
+		else
+		{
+			scanner.MustGetToken(TK_StringConst);
+	                ReplaceString(&mape->label, scanner.string);
+	        }
 	}
 	else if (!stricmp(pname, "next"))
 	{
@@ -523,9 +533,38 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 	}
 	else if (!stricmp(pname, "episode"))
 	{
-		char *lname = ParseMultiString(scanner, 1);
-		if (!lname) return 0;
-		M_AddEpisode(mape->mapname, lname);
+		if (scanner.CheckToken(TK_Identifier))
+		{
+			if (!stricmp(scanner.string, "clear")) M_ClearEpisodes();
+			else
+			{
+				scanner.ErrorF("Either 'clear' or string constant expected");
+				return 0;
+			}
+		}
+		else
+		{
+			char lumpname[9] = {0};
+			char *alttext = NULL;
+			char *key = NULL;
+
+			ParseLumpName(scanner, lumpname);
+			if (scanner.CheckToken(','))
+			{
+				scanner.MustGetToken(TK_StringConst);
+				alttext = strdup(scanner.string);
+				if (scanner.CheckToken(','))
+				{
+					scanner.MustGetToken(TK_StringConst);
+					key = strdup(scanner.string);
+				}
+			}
+
+			M_AddEpisode(mape->mapname, lumpname, alttext, key);
+
+			if (alttext) free(alttext);
+			if (key) free(key);
+		}
 	}
 	else if (!stricmp(pname, "bossaction"))
 	{


### PR DESCRIPTION
Fix this case: `episode = "", "test"`