### PR TITLE
add ftell() and fseek() implementations for DEHACKED lumps

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -145,7 +145,8 @@ static int dehfseek(DEHFILE *fp, long offset)
   else
   {
     long total = (fp->inp - fp->lump) + fp->size;
-    fp->inp = fp->lump + BETWEEN(0, total, offset);
+    offset = BETWEEN(0, total, offset);
+    fp->inp = fp->lump + offset;
     fp->size = total - offset;
     return 0;
   }

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -133,6 +133,24 @@ static int dehfgetc(DEHFILE *fp)
     fp->size--, *fp->inp++ : EOF;
 }
 
+static long dehftell(DEHFILE *fp)
+{
+  return !fp->lump ? ftell(fp->f) : (fp->inp - fp->lump);
+}
+
+static int dehfseek(DEHFILE *fp, long offset)
+{
+  if (!fp->lump)
+    return fseek(fp->f, offset, SEEK_SET);
+  else
+  {
+    long total = (fp->inp - fp->lump) + fp->size;
+    fp->inp = fp->lump + BETWEEN(0, total, offset);
+    fp->size = total - offset;
+    return 0;
+  }
+}
+
 // haleyjd 9/22/99
 int HelperThing = -1;     // in P_SpawnMapThing to substitute helper thing
 
@@ -1665,8 +1683,7 @@ void ProcessDehFile(const char *filename, const char *outfilename, int lumpnum)
       else if (last_i >= 10 && last_i < DEH_BLOCKMAX-1) // restrict to BEX style lumps
         { // process that same line again with the last valid block code handler
           i = last_i;
-          if (!filein->lump)
-            fseek(filein->f, filepos, SEEK_SET);
+          dehfseek(filein, filepos);
         }
 
       if (fileout)
@@ -1674,8 +1691,7 @@ void ProcessDehFile(const char *filename, const char *outfilename, int lumpnum)
                 i, deh_blocks[i].key);
       deh_blocks[i].fptr(filein,fileout,inbuffer);  // call function
 
-      if (!filein->lump) // back up line start
-        filepos = ftell(filein->f);
+      filepos = dehftell(filein); // back up line start
     }
 
   if (infile.lump)


### PR DESCRIPTION
This allows the DEH parser to roll back to the start of a line
following a blank line and re-process it with the last valid block
code handler, even if the DEHACKED patch is read from a lump instead
of a regular file.

Fixes #312.