### PR TITLE
Sound Quirks Fix

### DIFF
--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -326,7 +326,7 @@ static void S_StartSoundAtVolume(degenmobj_t *origin, int sfx_id, int volume)
   // kill old sound
   for (cnum=0 ; cnum<numChannels ; cnum++)
     if (channels[cnum].sfxinfo && channels[cnum].origin == origin &&
-        (default_comp[comp_sound] || channels[cnum].is_pickup == is_pickup))
+        (default_comp[comp_sound] && channels[cnum].is_pickup == is_pickup))
       {
         S_StopChannel(cnum);
         break;


### PR DESCRIPTION
Changes an `or` statement to an `and` in a check for stopping sound. The 'kill old sound' code is supposed to emulate a quirk with item pickup sounds however it was applying the quirk to all sounds. Changing the 'or' to an 'and' fixes this. I know that the sound quirks was changed to be a setting separated from -complevel but I think it'd still be a nice addition to have this fix for the quirks.