### PR TITLE
introduce a supplemental data directory "PRBOOMDATADIR"

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -179,6 +179,7 @@ set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_PREV})
 set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_PREV})
 
 set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/share/games/doom" CACHE PATH "Path to look for WAD files")
+set(PRBOOMDATADIR "${CMAKE_INSTALL_PREFIX}/share/${PACKAGE_TARNAME}" CACHE PATH "Path to install supplemental files")
 
 option(SIMPLECHECKS "Enable checks which only impose significant overhead if a posible error is detected" ON)
 option(ZONEIDCHECK "Enable id checks on zone blocks, to detect corrupted and illegally freed blocks" ON)

--- a/prboom2/cmake/config.h.cin
+++ b/prboom2/cmake/config.h.cin
@@ -5,6 +5,7 @@
 #cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
 
 #cmakedefine DOOMWADDIR "@DOOMWADDIR@"
+#cmakedefine PRBOOMDATADIR "@PRBOOMDATADIR@"
 
 #cmakedefine WORDS_BIGENDIAN
 

--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -367,4 +367,4 @@ add_custom_command(
     DEPENDS rdatawad ${WAD_SRC}
 )
 add_custom_target(prboomwad DEPENDS ${WAD_DATA_PATH})
-install(FILES ${WAD_DATA_PATH} DESTINATION ${DOOMWADDIR} COMPONENT "PrBoom-Plus internal WAD")
+install(FILES ${WAD_DATA_PATH} DESTINATION ${PRBOOMDATADIR} COMPONENT "PrBoom-Plus internal WAD")

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -472,6 +472,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
   } search0[] = {
     {NULL, NULL, NULL, I_DoomExeDir}, // config directory
     {NULL}, // current working directory
+    {PRBOOMDATADIR}, // supplemental data directory
     {NULL, NULL, "DOOMWADDIR"}, // run-time $DOOMWADDIR
     {DOOMWADDIR}, // build-time configured DOOMWADDIR
     {NULL, "doom", "HOME"}, // ~/doom


### PR DESCRIPTION
Rationale:

 - Currently, we install `prboom-plus.wad` into `DOOMWADDIR` which
   defaults to `/usr/share/games/doom`. However, this is the exact
   directory where all other engines also expect to find their WAD
   files. Since `prboom-plus.wad` is very specific to PrBoom+ and of very
   little use for other engines, I feel it is safer to keep this file in
   a separate directory that belongs to PrBoom+ only.

   Currently, this defaults to `/usr/share/prboom-plus`.

 - I am going to add this directory as a base search path for global,
   i.e. system-wide installed, autoload data.

   As a very specific example, I am going to remove all hard-coded
   special-casing for NERVE.wad and replace this with an UMAPINFO.lmp
   file that gets autoloaded whenever the corresponding PWAD is loaded
   from the command line (except, of course, if the `-noload`
   parameter was also given - which needs to be fixed first).