### PR TITLE
fix playback of complevel 11 demo with UMAPINFO

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3927,6 +3927,7 @@ const byte* G_ReadDemoHeaderEx(const byte *demo_p, size_t size, unsigned int par
 
     // ano - jun2019 - this is to support other demovers effectively?
     // while still having the extended features
+    header_p = demo_p;
     demover = *demo_p++;
 
   }


### PR DESCRIPTION
`header_p` used to determine complevel from signature here: https://github.com/coelckers/prboom-plus/blob/336a7ee69fa1e0e63a611fd3a6259ca56f3bfdc6/prboom2/src/g_game.c#L4062

How to reproduce: record complevel 11 demo with loaded UMAPINFO and play it back.