### PR TITLE
UMAPINFO: entries without defined 'levelname' fall back to default

### DIFF
--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -737,7 +737,7 @@ void HU_Start(void)
     &message_list
   );
 
-  if (gamemapinfo != NULL)
+  if (gamemapinfo && gamemapinfo->levelname)
   {
 	  if (gamemapinfo->label)
 		  s = gamemapinfo->label;
@@ -752,7 +752,6 @@ void HU_Start(void)
 		  HUlib_addCharToTextLine(&w_title, ' ');
 	  }
 	  s = gamemapinfo->levelname;
-	  if (!s) s = "Unnamed";
 	  while (*s)
 		  HUlib_addCharToTextLine(&w_title, *(s++));
 


### PR DESCRIPTION
For example:
```
map MAP01
{
	episode = "E1TITLE", "Title"
}
```
Currently, with this UMAPINFO, levelname for MAP01 is "Unnamed".