### PR TITLE
UMAPINFO: fix default intermission

### DIFF
--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -323,7 +323,7 @@ Thingtypes:
 Revisions:
 
 Rev 2.1 (@rfomin, June 22 2021)
- * Lookup for default backrop if 'interbackdrop' is not specified.
+ * Lookup for default backdrop if 'interbackdrop' is not specified.
 
 Rev 2 (@fabiangreffrath, May 11 2021)
  * Introduce the new 'label' field to allow for overriding of the string that

--- a/prboom2/doc/umapinfo.txt
+++ b/prboom2/doc/umapinfo.txt
@@ -110,8 +110,8 @@ intertextsecret = "text"
 intertextsecret = clear
 
 ; Backdrop to be used for intertext and intertextsecret. If it does not specify
-; a valid flat, it will be drawn as a patch instead. If not specified the
-; FLOOR4_8 flat will be used, regardless of which map it is used on.
+; a valid flat, it will be drawn as a patch instead. If not specified and there is
+; no default for current map, the FLOOR4_8 flat will be used.
 interbackdrop = "graphic"
 
 ; Music to be used for intertext and intertextsecret. If not specified
@@ -155,9 +155,6 @@ hard coded implementation, with a few exceptions:
 -   levelpic: If not given, the status screen will instead print the map's name
     with a suitable font (PrBoom uses STFxxx) to ensure that the proper name is
     used.
-
--   interbackdrop: This will not look up the default backdrop for a given map
-    but always use FLOOR4_8.
 
 Example:
 
@@ -324,6 +321,9 @@ Thingtypes:
 
 
 Revisions:
+
+Rev 2.1 (@rfomin, June 22 2021)
+ * Lookup for default backrop if 'interbackdrop' is not specified.
 
 Rev 2 (@fabiangreffrath, May 11 2021)
  * Introduce the new 'label' field to allow for overriding of the string that

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -78,6 +78,8 @@ int midstage;                 // whether we're in "mid-stage"
 //
 void F_StartFinale (void)
 {
+  dboolean mus_changed = false;
+
   gameaction = ga_nothing;
   gamestate = GS_FINALE;
   automapmode &= ~am_active;
@@ -85,10 +87,17 @@ void F_StartFinale (void)
   // killough 3/28/98: clear accelerative text flags
   acceleratestage = midstage = 0;
 
-	if (gamemapinfo)
+  finaletext = NULL;
+  finaleflat = NULL;
+
+	if (gamemapinfo && gamemapinfo->intermusic[0])
 	{
-		FMI_StartFinale();
-		return;
+		int l = W_CheckNumForName(gamemapinfo->intermusic);
+		if (l >= 0)
+		{
+			S_ChangeMusInfoMusic(l, true);
+			mus_changed = true;
+		}
 	}
   
   // Okay - IWAD dependend stuff.
@@ -101,7 +110,7 @@ void F_StartFinale (void)
     case registered:
     case retail:
     {
-      S_ChangeMusic(mus_victor, true);
+      if (!mus_changed) S_ChangeMusic(mus_victor, true);
 
       switch (gameepisode)
       {
@@ -131,7 +140,7 @@ void F_StartFinale (void)
     // DOOM II and missions packs with E1, M34
     case commercial:
     {
-      S_ChangeMusic(mus_read_m, true);
+      if (!mus_changed) S_ChangeMusic(mus_read_m, true);
 
       // Ty 08/27/98 - added the gamemission logic
       switch (gamemap)
@@ -181,11 +190,16 @@ void F_StartFinale (void)
 
     // Indeterminate.
     default:  // Ty 03/30/98 - not externalized
-         S_ChangeMusic(mus_read_m, true);
+         if (!mus_changed) S_ChangeMusic(mus_read_m, true);
          finaleflat = "F_SKY1"; // Not used anywhere else.
          finaletext = s_C1TEXT;  // FIXME - other text, music?
          break;
   }
+
+	if (gamemapinfo)
+	{
+		FMI_StartFinale();
+	}
 
   finalestage = 0;
   finalecount = 0;

--- a/prboom2/src/f_finale2.c
+++ b/prboom2/src/f_finale2.c
@@ -75,19 +75,13 @@ void FMI_StartFinale(void)
 
 	if (!finaletext) finaletext = "The End";	// this is to avoid a crash on a missing text in the last map.
 
-	finaleflat = gamemapinfo->interbackdrop[0] ? gamemapinfo->interbackdrop : "FLOOR4_8";	// use a single fallback for all maps.
-	if (gamemapinfo->intermusic[0])
+	if (gamemapinfo->interbackdrop[0])
 	{
-		int l = W_CheckNumForName(gamemapinfo->intermusic);
-		if (l >= 0) S_ChangeMusInfoMusic(l, true);
-	}
-	else
-	{
-		S_ChangeMusic(gamemode == commercial ? mus_read_m : mus_victor, true);
+		finaleflat = gamemapinfo->interbackdrop[0];
 	}
 
-	finalestage = 0;
-	finalecount = 0;
+	if (!finaleflat) finaleflat = "FLOOR4_8";	// use a single fallback for all maps.
+
 	using_FMI = true;
 }
 


### PR DESCRIPTION
If, for example, MAP06 has UMAPINFO entry, there is currently no way to keep the default intermission screen.

Test wad: [intermission.zip](https://github.com/coelckers/prboom-plus/files/6692451/intermission.zip)

After this change, this is no longer the case:
https://github.com/coelckers/prboom-plus/blob/d7e0101a63fd2174a0d10b4444b78981d3b1160e/prboom2/doc/umapinfo.txt#L159-L160