### PR TITLE
OpenGL: Don't bleed walls through sky floors

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1918,8 +1918,7 @@ bottomtexture:
       }
       else
       {
-        if (bs->floorpic == skyflatnum &&// fs->floorpic != skyflatnum &&
-          bottomtexture == NO_TEXTURE && midtexture == NO_TEXTURE)
+        if (bottomtexture == NO_TEXTURE && midtexture == NO_TEXTURE)
         {
           wall.ytop=(float)max_floor/MAP_SCALE;
           gld_AddSkyTexture(&wall, frontsector->sky, backsector->sky, SKY_CEILING);


### PR DESCRIPTION
This is a prospective fix for #380. I would appreciate testing on it as many mapping tricks rely on strange software renderer sky behavior.

I have checked this against my test WAD that contains many/most of the weird sky tricks I've encountered, but there are always more.