### PR TITLE
Account for proper crosshair offsets when locked on to monsters.

### DIFF
--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -2287,13 +2287,13 @@ void SetCrosshairTarget(void)
 
       if (!hudadd_crosshair_scale)
       {
-        crosshair.target_screen_x = winx;
-        crosshair.target_screen_y = SCREENHEIGHT - winy;
+        crosshair.target_screen_x = winx - (crosshair.w / 2);
+        crosshair.target_screen_y = SCREENHEIGHT - winy - (crosshair.h / 2);
       }
       else
       {
-        crosshair.target_screen_x = (winx - params->deltax1) * 320.0f / params->video->width;
-        crosshair.target_screen_y = 200 - (winy - params->deltay1) * 200.0f / params->video->height;
+        crosshair.target_screen_x = (winx - params->deltax1) * 320.0f / params->video->width - (crosshair.w / 2);
+        crosshair.target_screen_y = 200 - (winy - params->deltay1) * 200.0f / params->video->height - (crosshair.h / 2);
       }
     }
   }


### PR DESCRIPTION
When using the crosshair snapping feature, the dimensions of the crosshair aren't taken into effect. This leads to the crosshair being a bit down and to the right of where it should be. I've briefly detailed it here: https://www.doomworld.com/forum/post/2375077

Here's a fix for it.