### PR TITLE
UMAPINFO: update map entries instead of replacing

### DIFF
--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -343,6 +343,86 @@ void ReplaceString(char **pptr, const char *newstring)
 	*pptr = strdup(newstring);
 }
 
+static void UpdateMapEntry(MapEntry *mape, MapEntry *newe)
+{
+	if (newe->levelname)
+	{
+		ReplaceString(&mape->levelname, newe->levelname);
+	}
+	if (newe->label)
+	{
+		ReplaceString(&mape->label, newe->label);
+	}
+	if (newe->intertext)
+	{
+		ReplaceString(&mape->intertext, newe->intertext);
+	}
+	if (newe->intertextsecret)
+	{
+		ReplaceString(&mape->intertextsecret, newe->intertextsecret);
+	}
+	if (newe->levelpic[0])
+	{
+		strcpy(mape->levelpic, newe->levelpic);
+	}
+	if (newe->nextmap[0])
+	{
+		strcpy(mape->nextmap, newe->nextmap);
+	}
+	if (newe->music[0])
+	{
+		strcpy(mape->music, newe->music);
+	}
+	if (newe->skytexture[0])
+	{
+		strcpy(mape->skytexture, newe->skytexture);
+	}
+	if (newe->endpic[0])
+	{
+		strcpy(mape->endpic, newe->endpic);
+	}
+	if (newe->exitpic[0])
+	{
+		strcpy(mape->exitpic, newe->exitpic);
+	}
+	if (newe->enterpic[0])
+	{
+		strcpy(mape->enterpic, newe->enterpic);
+	}
+	if (newe->interbackdrop[0])
+	{
+		strcpy(mape->interbackdrop, newe->interbackdrop);
+	}
+	if (newe->intermusic[0])
+	{
+		strcpy(mape->intermusic, newe->intermusic);
+	}
+	if (newe->partime)
+	{
+		mape->partime = newe->partime;
+	}
+	if (newe->nointermission)
+	{
+		mape->nointermission = newe->nointermission;
+	}
+	if (newe->numbossactions)
+	{
+		mape->numbossactions = newe->numbossactions;
+		if (mape->numbossactions == -1)
+		{
+			if (mape->bossactions) free(mape->bossactions);
+			mape->bossactions = NULL;
+		}
+		else
+		{
+			mape->bossactions = (struct BossAction *)realloc(mape->bossactions,
+				sizeof(struct BossAction) * mape->numbossactions);
+			memcpy(mape->bossactions, newe->bossactions,
+				sizeof(struct BossAction) * mape->numbossactions);
+		}
+	}
+}
+
 // -----------------------------------------------
 //
 // Parses a set of string and concatenates them
@@ -699,13 +779,13 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 			}
 		}
 
-		// Does this property already exist? If yes, replace it.
+		// Does this property already exist? If yes, update it.
 		for(i = 0; i < Maps.mapcount; i++)
 		{
 			if (!strcmp(parsed.mapname, Maps.maps[i].mapname))
 			{
-				FreeMap(&Maps.maps[i]);
-				Maps.maps[i] = parsed;
+				UpdateMapEntry(&Maps.maps[i], &parsed);
+				FreeMap(&parsed);
 				break;
 			}
 		}


### PR DESCRIPTION
Updates map entries instead of replacing them when parsing multiple UMPAINFO lumps.