### PR TITLE
Adjust sky offets for non-90 FOVs.

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -207,7 +207,7 @@ void gld_AddSkyTexture(GLWall *wall, int sky1, int sky2, int skytype)
       else
       {
         wall->skyyaw  = -2.0f*(((270.0f-(float)((viewangle+s->textureoffset)>>ANGLETOFINESHIFT)*360.0f/FINEANGLES)+90.0f)/90.0f/skyscale);
-        wall->skyymid = skyYShift+(((float)s->rowoffset/(float)FRACUNIT)/100.0f);
+        wall->skyymid = skyYShift+(((float)s->rowoffset/(float)FRACUNIT + 28.0f)/wall->gltexture->buffer_height)/skyscale;
       }
       wall->flag = (l->special == 272 ? GLDWF_SKY : GLDWF_SKYFLIP);
     }


### PR DESCRIPTION
This will adjust the sky offset for non-90 FOVs to address the oft-reported issues with sky scaling on WADs like Eviternity that have non-standard sky dimensions.