### PR TITLE
Do not remove active plats in v1.2 compat

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -87,9 +87,7 @@
 #include "d_deh.h"
 #include "e6y.h"
 
-#ifdef _WIN32
-#include "WIN/win_fopen.h"
-#endif
+#include "m_io.h"
 
 dboolean wasWiped = false;
 
@@ -220,7 +218,7 @@ void e6y_assert(const char *format, ...)
   va_list argptr;
   va_start(argptr,format);
   //if (!f)
-    f = fopen("d:\\a.txt", "ab+");
+    f = M_fopen("d:\\a.txt", "ab+");
   vfprintf(f, format, argptr);
   fclose(f);
   va_end(argptr);
@@ -272,6 +270,7 @@ prboom_comp_t prboom_comp[PC_MAX] = {
   {0x00000000, 0x02050007, 0, "-do_not_use_misc12_frame_parameters_in_a_mushroom"},
   {0x00000000, 0x02050102, 0, "-apply_mbf_codepointers_to_any_complevel"},
   {0x00000000, 0x02050104, 0, "-reset_monsterspawner_params_after_loading"},
+  {0x02050104, 0x02060200, 0, "-remove_active_plats"},
 };
 
 void e6y_InitCommandLine(void)
@@ -967,7 +966,7 @@ void e6y_WriteStats(void)
   tmpdata_t *all;
   size_t allkills_len=0, allitems_len=0, allsecrets_len=0;
 
-  f = fopen("levelstat.txt", "wb");
+  f = M_fopen("levelstat.txt", "wb");
   
   all = malloc(sizeof(*all) * numlevels);
   memset(&max, 0, sizeof(timetable_t));
@@ -1309,12 +1308,12 @@ int GetFullPath(const char* FileName, const char* ext, char *Buffer, size_t Buff
     switch(i)
     {
     case 0:
-      getcwd(dir, sizeof(dir));
+      M_getcwd(dir, sizeof(dir));
       break;
     case 1:
-      if (!getenv("DOOMWADDIR"))
+      if (!M_getenv("DOOMWADDIR"))
         continue;
-      strcpy(dir, getenv("DOOMWADDIR"));
+      strcpy(dir, M_getenv("DOOMWADDIR"));
       break;
     case 2:
       strcpy(dir, I_DoomExeDir());
@@ -1327,49 +1326,6 @@ int GetFullPath(const char* FileName, const char* ext, char *Buffer, size_t Buff
   }
 
   return false;
-}
-#endif
-
-#ifdef _WIN32
-#include <Mmsystem.h>
-#ifndef __GNUC__
-#pragma comment( lib, "winmm.lib" )
-#endif
-int mus_extend_volume;
-void I_midiOutSetVolumes(int volume)
-{
-  // NSM changed to work on the 0-15 volume scale,
-  // and to check mus_extend_volume itself.
-  
-  MMRESULT result;
-  int calcVolume;
-  MIDIOUTCAPS capabilities;
-  unsigned int i;
-
-  if (volume > 15)
-    volume = 15;
-  if (volume < 0)
-    volume = 0;
-  calcVolume = (65535 * volume / 15);
-
-  //SDL_LockAudio(); // this function doesn't touch anything the audio callback touches
-
-  //Device loop
-  for (i = 0; i < midiOutGetNumDevs(); i++)
-  {
-    //Get device capabilities
-    result = midiOutGetDevCaps(i, &capabilities, sizeof(capabilities));
-    if (result == MMSYSERR_NOERROR)
-    {
-      //Adjust volume on this candidate
-      if ((capabilities.dwSupport & MIDICAPS_VOLUME))
-      {
-        midiOutSetVolume((HMIDIOUT)i, MAKELONG(calcVolume, calcVolume));
-      }
-    }
-  }
-
-  //SDL_UnlockAudio();
 }
 #endif
 

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -255,6 +255,7 @@ enum
   PC_DO_NOT_USE_MISC12_FRAME_PARAMETERS_IN_A_MUSHROOM,
   PC_APPLY_MBF_CODEPOINTERS_TO_ANY_COMPLEVEL,
   PC_RESET_MONSTERSPAWNER_PARAMS_AFTER_LOADING,
+  PC_v12_REMOVE_ACTIVE_PLATS,
   PC_MAX
 };
 
@@ -355,10 +356,5 @@ void I_Warning(const char *message, ...);
 int I_MessageBox(const char* text, unsigned int type);
 
 dboolean SmoothEdges(unsigned char * buffer,int w, int h);
-
-#ifdef _WIN32
-extern int mus_extend_volume;
-void I_midiOutSetVolumes(int volume);
-#endif
 
 #endif

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -115,13 +115,13 @@ void T_PlatRaise(plat_t* plat)
           {
             case blazeDWUS:
             case downWaitUpStay:
+            case raiseAndChange:
             case genLift:
               P_RemoveActivePlat(plat);     // killough
               break;
 
-            case raiseAndChange:
             case raiseToNearestAndChange:
-            // In versions <= v1.2 these platform types always remain active.
+            // In versions before v1.666 these platform types always remain active.
             if (compatibility_level > doom_12_compatibility)
             {
               P_RemoveActivePlat(plat);

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -160,7 +160,6 @@ void T_PlatRaise(plat_t* plat)
             case raiseAndChange:
             case raiseToNearestAndChange:
               P_RemoveActivePlat(plat);
-
             default:
               break;
           }

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -115,13 +115,18 @@ void T_PlatRaise(plat_t* plat)
           {
             case blazeDWUS:
             case downWaitUpStay:
+            case genLift:
+              P_RemoveActivePlat(plat);     // killough
+              break;
+
             case raiseAndChange:
             case raiseToNearestAndChange:
-            case genLift:
-		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
-		    // downWaitUpStay always remain active.
-		    if (compatibility_level > doom_12_compatibility)
-              P_RemoveActivePlat(plat);     // killough
+            // In versions <= v1.2 these platform types always remain active.
+            if (compatibility_level > doom_12_compatibility)
+            {
+              P_RemoveActivePlat(plat);
+              break;
+            }
             default:
               break;
           }

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -118,8 +118,6 @@ void T_PlatRaise(plat_t* plat)
             case raiseAndChange:
             case raiseToNearestAndChange:
             case genLift:
-		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
-		    // downWaitUpStay always remain active.
 		    if (compatibility_level > doom_12_compatibility)
               P_RemoveActivePlat(plat);     // killough
             default:
@@ -159,11 +157,8 @@ void T_PlatRaise(plat_t* plat)
           {
             case raiseAndChange:
             case raiseToNearestAndChange:
-		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
-		    // downWaitUpStay always remain active.
-		    if (compatibility_level > doom_12_compatibility)
-                P_RemoveActivePlat(plat);
-            break;
+              P_RemoveActivePlat(plat);
+
             default:
               break;
           }

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -122,7 +122,7 @@ void T_PlatRaise(plat_t* plat)
 
             case raiseToNearestAndChange:
             // In versions before v1.666 these platform types always remain active.
-            if (compatibility_level > doom_12_compatibility)
+            if (compatibility_level > doom_12_compatibility || prboom_comp[PC_v12_REMOVE_ACTIVE_PLATS].state)
             {
               P_RemoveActivePlat(plat);
               break;

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -118,6 +118,9 @@ void T_PlatRaise(plat_t* plat)
             case raiseAndChange:
             case raiseToNearestAndChange:
             case genLift:
+		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
+		    // downWaitUpStay always remain active.
+		    if (compatibility_level > doom_12_compatibility)
               P_RemoveActivePlat(plat);     // killough
             default:
               break;
@@ -156,7 +159,11 @@ void T_PlatRaise(plat_t* plat)
           {
             case raiseAndChange:
             case raiseToNearestAndChange:
-              P_RemoveActivePlat(plat);
+		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
+		    // downWaitUpStay always remain active.
+		    if (compatibility_level > doom_12_compatibility)
+                P_RemoveActivePlat(plat);
+            break;
             default:
               break;
           }

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -118,6 +118,8 @@ void T_PlatRaise(plat_t* plat)
             case raiseAndChange:
             case raiseToNearestAndChange:
             case genLift:
+		    // SmileTheory: in versions <= v1.2 (at least), platform types besides
+		    // downWaitUpStay always remain active.
 		    if (compatibility_level > doom_12_compatibility)
               P_RemoveActivePlat(plat);     // killough
             default:

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2667,7 +2667,9 @@ void P_SpawnSpecials (void)
 
       case 17:
         // fire flickering
-        P_SpawnFireFlicker(sector);
+        // first introduced in official v1.4 beta
+        if (compatibility_level > doom_12_compatibility)
+          P_SpawnFireFlicker(sector);
         break;
     }
   }

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2667,9 +2667,7 @@ void P_SpawnSpecials (void)
 
       case 17:
         // fire flickering
-        // first introduced in official v1.4 beta
-        if (compatibility_level > doom_12_compatibility)
-          P_SpawnFireFlicker(sector);
+        P_SpawnFireFlicker(sector);
         break;
     }
   }


### PR DESCRIPTION
This is an adaptation of SmileTheory's commit [3fe7123](https://github.com/chocolate-doom/chocolate-doom/pull/1207/commits/3fe712316d947353a1576dd0bb91d3a395d8513b) (Emulate pre-v1.25 always active plats) from PR [#1207](https://github.com/chocolate-doom/chocolate-doom/pull/1207) on the Choco repo. Fixes #441.