### PR TITLE
Restrict Alt+Tab workaround to SDL versions <2.0.18

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1318,7 +1318,7 @@ void I_UpdateVideoMode(void)
 {
    SDL_version ver;
    SDL_GetVersion(&ver);
-   if (ver.major == 2 && ver.minor == 0 && ver.patch >= 14)
+   if (ver.major == 2 && ver.minor == 0 && (ver.patch == 14 || ver.patch == 16))
    {
       SDL_SetHintWithPriority(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1", SDL_HINT_OVERRIDE);
    }


### PR DESCRIPTION
The latest SDL2 version (2.0.18) allows Alt+Tab to work as intended. Moreover, using the SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS workaround with it loses the mouse when Alt-tabing away from a fullscreen prb+ session. Thus we restrict the workaround to the two earlier versions, the way it's currently done in Choco.
Fixes #435.