### PR TITLE
Fix bugs with UMAPINFO par times not showing.

### DIFF
--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -929,9 +929,10 @@ static void WI_drawTimeStats(int cnt_time, int cnt_total_time, int cnt_par)
   // killough 2/22/98: skip drawing par times on pwads
   // Ty 03/17/98: unless pars changed with deh patch
 
-  if (!(modifiedgame && !deh_pars) || (gamemission == pack_nerve && singleplayer))
+  if (!(modifiedgame && !deh_pars && !(gamemapinfo && gamemapinfo->partime > 0))
+          || (gamemission == pack_nerve && singleplayer))
   {
-    if (wbs->epsd < 4)
+    if (wbs->epsd < 4 || (gamemapinfo && gamemapinfo->partime > 0))
     {
       V_DrawNamePatch(320/2 + SP_TIMEX, SP_TIMEY, FB, par, CR_DEFAULT, VPT_STRETCH);
       WI_drawTime(320 - SP_TIMEX, SP_TIMEY, cnt_par);


### PR DESCRIPTION
Fix #450 by checking mapinfo when deciding whether or not to display par times.