### PR TITLE
fix demo playback warp consistency

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1600,6 +1600,8 @@ static void D_AutoloadDehPWadDir()
 //  line of execution so its stack space can be freed
 const char* doomverstr = NULL;
 
+int warpepisode = -1, warpmap = -1;
+
 static void D_DoomMainSetup(void)
 {
   int p,slot;
@@ -1783,7 +1785,10 @@ static void D_DoomMainSetup(void)
     if (gamemode == commercial)
     {
       if (p < myargc-1)
+      {
         startmap = atoi(myargv[p+1]);   // Ty 08/29/98 - add test if last parm
+        warpmap = startmap;
+      }
     }
     else    // 1/25/98 killough: fix -warp xxx from crashing Doom 1 / UD
     {
@@ -1798,6 +1803,8 @@ static void D_DoomMainSetup(void)
           {
             startmap = map;
           }
+          warpepisode = startepisode;
+          warpmap = startmap;
         }
       }
     }

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -91,7 +91,6 @@ extern const char *avi_shot_fname;
 extern dboolean doSkip;
 extern dboolean demo_stoponnext;
 extern dboolean demo_stoponend;
-extern dboolean demo_warp;
 
 extern int key_speed_up;
 extern int key_speed_down;
@@ -185,6 +184,7 @@ extern dboolean sound_inited_once;
 void e6y_I_uSleep(unsigned long usecs);
 void G_SkipDemoStart(void);
 void G_SkipDemoStop(void);
+void G_SkipDemoStartCheck(void);
 void G_SkipDemoCheck(void);
 int G_ReloadLevel(void);
 int G_GotoNextLevel(int *e, int *m);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -873,8 +873,6 @@ static void G_DoLoadLevel (void)
       memset (players[i].frags,0,sizeof(players[i].frags));
     }
 
-  e6y_G_DoWorldDone();//e6y
-
   // automatic pistol start when advancing from one level to the next
   if (pistolstart)
   {
@@ -1884,6 +1882,7 @@ void G_DoWorldDone (void)
   G_DoLoadLevel();
   gameaction = ga_nothing;
   AM_clearMarks();           //jff 4/12/98 clear any marks on the automap
+  e6y_G_DoWorldDone();//e6y
 }
 
 // killough 2/28/98: A ridiculously large number
@@ -2979,6 +2978,8 @@ void G_InitNew(skill_t skill, int episode, int map)
   gamemapinfo = G_LookupMapinfo(gameepisode, gamemap);
 
   totalleveltimes = 0; // cph
+
+  G_SkipDemoStartCheck();
 
   //jff 4/16/98 force marks on automap cleared every new level start
   AM_clearMarks();

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -873,6 +873,8 @@ static void G_DoLoadLevel (void)
       memset (players[i].frags,0,sizeof(players[i].frags));
     }
 
+  e6y_G_DoWorldDone();//e6y
+
   // automatic pistol start when advancing from one level to the next
   if (pistolstart)
   {
@@ -1882,7 +1884,6 @@ void G_DoWorldDone (void)
   G_DoLoadLevel();
   gameaction = ga_nothing;
   AM_clearMarks();           //jff 4/12/98 clear any marks on the automap
-  e6y_G_DoWorldDone();//e6y
 }
 
 // killough 2/28/98: A ridiculously large number


### PR DESCRIPTION
instead of G_DoWorldDone(), i.e. after the previous map.

This allows to actually warp to the first map of a demo, fixes #446.