### PR TITLE
Added option to show current game skill on the automap

### DIFF
--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -93,6 +93,9 @@ int hud_num;
 #define HU_MAP_TIME_Y      (4 + 4*hu_font['A'-HU_FONTSTART].height + HU_MAP_STAT_Y)
 #define HU_MAP_TOTALTIME_Y (5 + 5*hu_font['A'-HU_FONTSTART].height + HU_MAP_STAT_Y)
 
+#define HU_SKILLX (0)
+#define HU_SKILLY (6 + 6*hu_font['A'-HU_FONTSTART].height + (1 * hu_font['A'-HU_FONTSTART].height + 1))
+
 //jff 2/16/98 add ammo, health, armor widgets, 2/22/98 less gap
 #define HU_GAPY 8
 
@@ -166,6 +169,7 @@ static hu_textline_t  w_map_secrets;   //e6y secrets widgets automap
 static hu_textline_t  w_map_items;     //e6y items widgets automap
 static hu_textline_t  w_map_time;      //e6y level time widgets automap
 static hu_textline_t  w_map_totaltime; //e6y total time widgets automap
+static hu_textline_t  w_map_skill;
 
 static hu_textline_t  w_health_big;
 static hu_textline_t  w_medict_icon_big;
@@ -198,6 +202,7 @@ int hudcolor_xyco;  // color range of new coords on automap
 int hudcolor_mapstat_title;
 int hudcolor_mapstat_value;
 int hudcolor_mapstat_time;
+int hudcolor_skill;
 //jff 2/16/98 hud text colors, controls added
 int hudcolor_mesg;  // color range of scrolling messages
 int hudcolor_chat;  // color range of chat lines
@@ -232,6 +237,7 @@ extern char **mapnamest[];
 
 extern int map_point_coordinates;
 extern int map_level_stat;
+extern int map_skill;
 
 // key tables
 // jff 5/10/98 french support removed,
@@ -491,6 +497,17 @@ void HU_Start(void)
     HU_FONTSTART,
     hudcolor_titl,
     VPT_ALIGN_LEFT_BOTTOM
+  );
+
+  HUlib_initTextLine
+  (
+    &w_map_skill,
+    HU_SKILLX,
+    HU_SKILLY,
+    hu_font,
+    HU_FONTSTART,
+    hudcolor_skill,
+    VPT_ALIGN_LEFT
   );
 
   // create the hud health widget
@@ -2447,6 +2464,21 @@ void HU_Drawer(void)
           HUlib_addCharToTextLine(&w_coordz, *(s++));
         HUlib_drawTextLine(&w_coordz, false);
       }
+    }
+
+    if (map_skill)
+    {
+      static char str[24];
+      static const char *skillstrings[] = {
+        "", "I'm too young to die", "Hey, not too rough", "Hurt me plenty", "Ultra-Violence", "Nightmare!", NULL
+      };
+
+      sprintf(str, "%s", skillstrings[gameskill+1]);
+      HUlib_clearTextLine(&w_map_skill);
+      s = str;
+      while (*s)
+        HUlib_addCharToTextLine(&w_map_skill, *(s++));
+      HUlib_drawTextLine(&w_map_skill, false);
     }
 
     if (map_level_stat)

--- a/prboom2/src/hu_stuff.h
+++ b/prboom2/src/hu_stuff.h
@@ -82,6 +82,7 @@ extern int hudcolor_xyco;   /* color range of new coords on automap */
 extern int hudcolor_mapstat_title;
 extern int hudcolor_mapstat_value;
 extern int hudcolor_mapstat_time;
+extern int hudcolor_skill;
 /* jff 2/16/98 hud text colors, controls added */
 extern int hudcolor_mesg;   /* color range of scrolling messages    */
 extern int hudcolor_chat;   /* color range of chat lines            */

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -204,6 +204,7 @@ int mapcolor_me;    // cph
 
 extern int map_point_coordinates; // killough 10/98
 extern int map_level_stat;
+extern int map_skill;
 
 extern char* chat_macros[];  // chat macros
 extern const char* shiftxform;
@@ -2940,19 +2941,20 @@ setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen
 {
   {"Show Kills/Secrts/Items statistics",      S_YESNO,m_null,AU_X,AU_Y+0*8, {"map_level_stat"}},
   {"Show coordinates of automap pointer",     S_YESNO,m_null,AU_X,AU_Y+1*8, {"map_point_coord"}},  // killough 10/98
-  {"Show Secrets only after entering",        S_YESNO,m_null,AU_X,AU_Y+2*8, {"map_secret_after"}},
-  {"Update unexplored parts in automap mode", S_YESNO,m_null,AU_X,AU_Y+3*8, {"map_always_updates"}},
-  {"Grid cell size 8..256, -1 for autosize",  S_NUM,  m_null,AU_X,AU_Y+4*8, {"map_grid_size"}, 0, 0, M_ChangeMapGridSize},
-  {"Scroll / Zoom speed  (1..32)",            S_NUM,  m_null,AU_X,AU_Y+5*8, {"map_scroll_speed"}},
-  {"Use mouse wheel for zooming",             S_YESNO,m_null,AU_X,AU_Y+6*8, {"map_wheel_zoom"}},
-  {"Apply multisampling",                     S_YESNO,m_null,AU_X,AU_Y+7*8, {"map_use_multisamling"}, 0, 0, M_ChangeMapMultisamling},
+  {"Show current skill level",                S_YESNO,m_null,AU_X,AU_Y+2*8, {"map_skill"}},
+  {"Show Secrets only after entering",        S_YESNO,m_null,AU_X,AU_Y+3*8, {"map_secret_after"}},
+  {"Update unexplored parts in automap mode", S_YESNO,m_null,AU_X,AU_Y+4*8, {"map_always_updates"}},
+  {"Grid cell size 8..256, -1 for autosize",  S_NUM,  m_null,AU_X,AU_Y+5*8, {"map_grid_size"}, 0, 0, M_ChangeMapGridSize},
+  {"Scroll / Zoom speed  (1..32)",            S_NUM,  m_null,AU_X,AU_Y+6*8, {"map_scroll_speed"}},
+  {"Use mouse wheel for zooming",             S_YESNO,m_null,AU_X,AU_Y+7*8, {"map_wheel_zoom"}},
+  {"Apply multisampling",                     S_YESNO,m_null,AU_X,AU_Y+8*8, {"map_use_multisamling"}, 0, 0, M_ChangeMapMultisamling},
 #ifdef GL_DOOM
-  {"Enable textured display",                 S_YESNO,m_null,AU_X,AU_Y+8*8, {"map_textured"}, 0, 0, M_ChangeMapTextured},
-  {"Things appearance",                       S_CHOICE,m_null,AU_X,AU_Y+9*8, {"map_things_appearance"}, 0, 0, NULL, map_things_appearance_list},
-  {"Translucency percentage",                 S_SKIP|S_TITLE,m_null,AU_X,AU_Y+10*8},
-  {"Textured automap",                        S_NUM,  m_null,AU_X,AU_Y+11*8, {"map_textured_trans"}},
-  {"Textured automap in overlay mode",        S_NUM,  m_null,AU_X,AU_Y+12*8, {"map_textured_overlay_trans"}},
-  {"Lines in overlay mode",                   S_NUM,  m_null,AU_X,AU_Y+13*8, {"map_lines_overlay_trans"}},
+  {"Enable textured display",                 S_YESNO,m_null,AU_X,AU_Y+9*8, {"map_textured"}, 0, 0, M_ChangeMapTextured},
+  {"Things appearance",                       S_CHOICE,m_null,AU_X,AU_Y+10*8, {"map_things_appearance"}, 0, 0, NULL, map_things_appearance_list},
+  {"Translucency percentage",                 S_SKIP|S_TITLE,m_null,AU_X,AU_Y+11*8},
+  {"Textured automap",                        S_NUM,  m_null,AU_X,AU_Y+12*8, {"map_textured_trans"}},
+  {"Textured automap in overlay mode",        S_NUM,  m_null,AU_X,AU_Y+13*8, {"map_textured_overlay_trans"}},
+  {"Lines in overlay mode",                   S_NUM,  m_null,AU_X,AU_Y+14*8, {"map_lines_overlay_trans"}},
 #endif
 
   // Button for resetting to defaults
@@ -2981,10 +2983,11 @@ setup_menu_t auto_settings2[] =  // 2st AutoMap Settings screen
 
   {"AUTOMAP LEVEL TITLE COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+12*8, {"hudcolor_titl"}},
   {"AUTOMAP COORDINATES COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+13*8, {"hudcolor_xyco"}},
+  {"AUTOMAP SKILL LEVEL COLOR"      ,S_CRITEM,m_null,AU_X,AU_Y+14*8, {"hudcolor_skill"}},
 
-  {"Automap Statistics Titles Color",S_CRITEM,m_null,AU_X,AU_Y+14*8, {"hudcolor_mapstat_title"}},
-  {"Automap Statistics Values Color",S_CRITEM,m_null,AU_X,AU_Y+15*8, {"hudcolor_mapstat_value"}},
-  {"Automap Statistics Time Color"  ,S_CRITEM,m_null,AU_X,AU_Y+16*8, {"hudcolor_mapstat_time"}},
+  {"Automap Statistics Titles Color",S_CRITEM,m_null,AU_X,AU_Y+15*8, {"hudcolor_mapstat_title"}},
+  {"Automap Statistics Values Color",S_CRITEM,m_null,AU_X,AU_Y+16*8, {"hudcolor_mapstat_value"}},
+  {"Automap Statistics Time Color"  ,S_CRITEM,m_null,AU_X,AU_Y+17*8, {"hudcolor_mapstat_time"}},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -298,6 +298,7 @@ extern const char* S_music_files[]; // cournia
  */
 int map_point_coordinates;
 int map_level_stat;
+int map_skill;
 
 default_t defaults[] =
 {
@@ -870,6 +871,8 @@ default_t defaults[] =
    def_bool,ss_auto},
   {"map_level_stat", {&map_level_stat}, {1},0,1,
    def_bool,ss_auto},
+  {"map_skill", {&map_skill}, {0},0,1,
+   def_bool,ss_auto},
   //jff 1/7/98 end additions for automap
   {"automapmode", {(int*)&automapmode}, {am_follow}, 0, 31, // CPhipps - remember automap mode
    def_hex,ss_none}, // automap mode
@@ -914,6 +917,8 @@ default_t defaults[] =
    def_int,ss_auto}, // color range used for automap statistics for data
   {"hudcolor_mapstat_time", {&hudcolor_mapstat_time}, {2},0,9,    // gray range
    def_int,ss_auto}, // color range used for automap statistics for level time and total time
+  {"hudcolor_skill", {&hudcolor_skill}, {6},0,9,  // red range
+   def_int,ss_auto}, // color range used for automap skill level
   {"hudcolor_mesg", {&hudcolor_mesg}, {6},0,9,  // red range
    def_int,ss_mess}, // color range used for messages during play
   {"hudcolor_chat", {&hudcolor_chat}, {5},0,9,  // gold range


### PR DESCRIPTION
This adds a new automap widget which shows the current game skill on the automap.
Also added its option to the "automap" setup menu (turned off by default), and and its color (6, red range by default).

I'm not sure about the location of the widget on the automap. Initially I thought about putting it on the right bottom, but I couldn't figure out a way to prevent longer strings to go off screen.