### PR TITLE
New cheat that shows skill level

### DIFF
--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -94,6 +94,7 @@ static void cheat_megaarmour();
 static void cheat_health();
 static void cheat_notarget();
 static void cheat_fly();
+static void cheat_skill();
 static void cheat_comp_ext();
 static void cheat_shorttics();
 
@@ -191,6 +192,8 @@ cheatseq_t cheat[] = {
   CHEAT("notarget",   NULL,               cht_never, cheat_notarget, 0),
   // fly mode is active
   CHEAT("fly",        NULL,               cht_never, cheat_fly, 0),
+  // Show skill level
+  CHEAT("skill",      NULL,               always, cheat_skill, 0),
 
   // Complevels with parameters
   CHEAT("tntcl",      NULL,               cht_never, cheat_comp_ext, -2),
@@ -689,6 +692,11 @@ static void cheat_fly()
       plyr->message = "Fly mode OFF";
     }
   }
+}
+
+static void cheat_skill()
+{
+  doom_printf("Skill: %d", gameskill+1);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds a simple cheat which shows the current skill level as a number.

I thought about showing the skill names instead of their corresponding number, but since we don't have any skilltable array like in the equivalent implementation on Crispy Doom, that would mean using a hard-coded table only for this function, which I don't know how acceptable that would be here. Let me know your thoughts about this!