### PR TITLE
Move default data directory to XDG_DATA_HOME on Linux

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -46,7 +46,6 @@
 #include <time.h>
 #include <signal.h>
 #include <string.h>
-#include <dirent.h>
 #ifdef _MSC_VER
 #define    F_OK    0    /* Check for file existence */
 #define    W_OK    2    /* Check for write permission */
@@ -351,7 +350,7 @@ static const char prboom_dir[] = {"prboom-plus"};
 const char *I_DoomExeDir(void)
 {
   static char *base;
-  DIR *data_dir;
+  struct stat data_dir;
 
   if (!base)        // cache multiple requests
     {
@@ -365,10 +364,10 @@ const char *I_DoomExeDir(void)
       base = malloc(p_len);
       snprintf(base, p_len, "%s/.%s", home, prboom_dir);
 
-      data_dir = opendir(base);
-      if (data_dir)
+      stat(base, &data_dir);
+      if (S_ISDIR(data_dir.st_mode))
         {
-          closedir(data_dir);
+          return base;
         }
       else
         {

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -354,14 +354,16 @@ const char *I_DoomExeDir(void)
   if (!base)        // cache multiple requests
     {
       char *home = getenv("HOME");
+      char *p_home = strdup(home);
       size_t len = strlen(home);
       size_t p_len = (len + strlen(prboom_dir) + 3);
 
       // I've had trouble with trailing slashes before...
-      if (home[len-1] == '/') home[len-1] = 0;
+      if (p_home[len-1] == '/') p_home[len-1] = 0;
 
       base = malloc(p_len);
-      snprintf(base, p_len, "%s/.%s", home, prboom_dir);
+      snprintf(base, p_len, "%s/.%s", p_home, prboom_dir);
+      free(p_home);
 
       stat(base, &data_dir);
       if (!S_ISDIR(data_dir.st_mode))
@@ -370,12 +372,12 @@ const char *I_DoomExeDir(void)
           size_t prefsize = strlen(prefpath);
 
           free(base);
-          base = malloc(prefsize);
-          strcpy(base, prefpath);
+          base = strdup(prefpath);
           // SDL_GetPrefPath always returns with trailing slash
           if (base[prefsize-1] == '/') base[prefsize-1] = 0;
           SDL_free(prefpath);
         }
+//    mkdir(base, S_IRUSR | S_IWUSR | S_IXUSR);
     }
   return base;
 }

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -365,9 +365,12 @@ const char *I_DoomExeDir(void)
       snprintf(base, p_len, "%s/.%s", p_home, prboom_dir);
       free(p_home);
 
+      // if ~/.$prboom_dir doesn't exist,
+      // create and use directory in XDG_DATA_HOME
       stat(base, &data_dir);
       if (!S_ISDIR(data_dir.st_mode))
         {
+          // SDL creates this directory if it doesn't exist
           char *prefpath = SDL_GetPrefPath("", prboom_dir);
           size_t prefsize = strlen(prefpath);
 

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -344,7 +344,6 @@ const char* I_GetTempDir(void)
 // cph - V.Aguilar (5/30/99) suggested return ~/.lxdoom/, creating
 //  if non-existant
 // cph 2006/07/23 - give prboom+ its own dir
-// static const char prboom_dir[] = {"/.prboom-plus"}; // Mead rem extra slash 8/21/03
 static const char prboom_dir[] = {"prboom-plus"};
 
 const char *I_DoomExeDir(void)
@@ -365,11 +364,7 @@ const char *I_DoomExeDir(void)
       snprintf(base, p_len, "%s/.%s", home, prboom_dir);
 
       stat(base, &data_dir);
-      if (S_ISDIR(data_dir.st_mode))
-        {
-          return base;
-        }
-      else
+      if (!S_ISDIR(data_dir.st_mode))
         {
           char *prefpath = SDL_GetPrefPath("", prboom_dir);
           size_t prefsize = strlen(prefpath);
@@ -381,7 +376,6 @@ const char *I_DoomExeDir(void)
           if (base[prefsize-1] == '/') base[prefsize-1] = 0;
           SDL_free(prefpath);
         }
-      mkdir(base, S_IRUSR | S_IWUSR | S_IXUSR); // Make sure it exists
     }
   return base;
 }

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -374,6 +374,7 @@ const char *I_DoomExeDir(void)
           char *prefpath = SDL_GetPrefPath("", prboom_dir);
           size_t prefsize = strlen(prefpath);
 
+          free(base);
           base = malloc(prefsize);
           strcpy(base, prefpath);
           // SDL_GetPrefPath always returns with trailing slash


### PR DESCRIPTION
This takes the current default into account, so it would only be noticeable on a fresh install.

Also a minor refactor for generating the old path.