### PR TITLE
check return status when checking for old prboom_dir

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -367,8 +367,7 @@ const char *I_DoomExeDir(void)
 
       // if ~/.$prboom_dir doesn't exist,
       // create and use directory in XDG_DATA_HOME
-      stat(base, &data_dir);
-      if (!S_ISDIR(data_dir.st_mode))
+      if (stat(base, &data_dir) || !S_ISDIR(data_dir.st_mode))
         {
           // SDL creates this directory if it doesn't exist
           char *prefpath = SDL_GetPrefPath("", prboom_dir);


### PR DESCRIPTION
Fixes rare occasions where the old path would be returned because I didn't check for `stat()` failure.