### PR TITLE
Don't overwrite user-configured custom docdir

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -22,6 +22,10 @@ include(TargetArch)
 include(TestBigEndian)
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 
+# Check if a CMAKE_INSTALL_DOCDIR is provided before GNUInstallDirs sets its
+# own default; this lets us set our own PrBoom-Plus default docdir later
+# without clobbering a user-configured one
+set(CUSTOM_DOCDIR "${CMAKE_INSTALL_DOCDIR}")
 include(GNUInstallDirs)
 
 # Automated dependencies discovery, mostly needed for MSVC
@@ -38,7 +42,9 @@ set(PACKAGE_TARNAME "prboom-plus")
 set(PACKAGE_VERSION "${PROJECT_VERSION}")
 set(PACKAGE_HOMEPAGE "${PROJECT_HOMEPAGE_URL}")
 set(PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
-set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PACKAGE_TARNAME}" CACHE PATH "" FORCE)
+if(NOT CUSTOM_DOCDIR)
+  set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PACKAGE_TARNAME}" CACHE PATH "" FORCE)
+endif()
 
 include(CheckSymbolExists)
 


### PR DESCRIPTION
We want to provide a default docdir for PrBoom-Plus, but let's not
overwrite the custom docdir a user may provide.