### PR TITLE
Generate mixer buffer size from sample rate

### DIFF
--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -231,7 +231,8 @@ static int getSliceSize(void)
 {
   int limit, n;
 
-  if (snd_samplecount) return snd_samplecount;
+  if (snd_samplecount >= 32)
+    return snd_samplecount * snd_samplerate / 11025;
 
   limit = snd_samplerate / TICRATE;
 

--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -227,6 +227,23 @@ static int addsfx(int sfxid, int channel, const unsigned char *data, size_t len)
   return channel;
 }
 
+static int getBufferSize(void)
+{
+  int limit, i;
+
+//if (snd_samplecount) return snd_samplecount;
+
+  limit = snd_samplerate / TICRATE;
+
+  // adapted from Chocolate Doom
+  // gets the smallest power of 2, for feeding into SDL
+  for (i = 0;; ++i)
+  {
+    if ((1 << (i + 1)) > limit)
+      return (1 << i);
+  }
+}
+
 static void updateSoundParams(int handle, int volume, int seperation, int pitch)
 {
   int slot = handle;
@@ -679,7 +696,7 @@ void I_InitSound(void)
     /* Initialize variables */
     audio_rate = snd_samplerate;
     audio_channels = 2;
-    audio_buffers = snd_samplecount * snd_samplerate / 11025;
+    audio_buffers = getBufferSize();
 
     if (Mix_OpenAudioDevice(audio_rate, MIX_DEFAULT_FORMAT, audio_channels, audio_buffers,
                             NULL, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
@@ -709,7 +726,7 @@ void I_InitSound(void)
     audio.format = AUDIO_S16LSB;
 #endif
     audio.channels = 2;
-    audio.samples = snd_samplecount * snd_samplerate / 11025;
+    audio.samples = getBufferSize();
     audio.callback = I_UpdateSound;
     if ( SDL_OpenAudio(&audio, NULL) < 0 )
     {

--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -231,7 +231,7 @@ static int getBufferSize(void)
 {
   int limit, i;
 
-//if (snd_samplecount) return snd_samplecount;
+  if (snd_samplecount) return snd_samplecount;
 
   limit = snd_samplerate / TICRATE;
 

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -436,7 +436,7 @@ default_t defaults[] =
   {"pitched_sounds",{&pitched_sounds},{0},0,1, // killough 2/21/98
    def_bool,ss_none}, // enables variable pitch in sound effects (from id's original code)
   {"samplerate",{&snd_samplerate},{44100},11025,48000, def_int,ss_none},
-  {"slice_samplecount",{&snd_samplecount},{512},32,8192, def_int,ss_none},
+  {"slice_samplecount",{&snd_samplecount},{0},32,8192, def_int,ss_none},
   {"sfx_volume",{&snd_SfxVolume},{8},0,15, def_int,ss_none},
   {"music_volume",{&snd_MusicVolume},{8},0,15, def_int,ss_none},
   {"mus_pause_opt",{&mus_pause_opt},{1},0,2, // CPhipps - music pausing

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -436,7 +436,7 @@ default_t defaults[] =
   {"pitched_sounds",{&pitched_sounds},{0},0,1, // killough 2/21/98
    def_bool,ss_none}, // enables variable pitch in sound effects (from id's original code)
   {"samplerate",{&snd_samplerate},{44100},11025,48000, def_int,ss_none},
-  {"slice_samplecount",{&snd_samplecount},{0},32,8192, def_int,ss_none},
+  {"slice_samplecount",{&snd_samplecount},{0},0,8192, def_int,ss_none},
   {"sfx_volume",{&snd_SfxVolume},{8},0,15, def_int,ss_none},
   {"music_volume",{&snd_MusicVolume},{8},0,15, def_int,ss_none},
   {"mus_pause_opt",{&mus_pause_opt},{1},0,2, // CPhipps - music pausing


### PR DESCRIPTION
Fixes #429, but breaks `slice_samplecount` behavior. Suggested re-usage on line 234.