### PR TITLE
Allow uppercase episode shortcuts in UMAPINFO

### DIFF
--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -557,6 +557,7 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 				{
 					scanner.MustGetToken(TK_StringConst);
 					key = strdup(scanner.string);
+					key[0] = tolower(key[0]);
 				}
 			}
 


### PR DESCRIPTION
Fixes in cases like Sigil, which uses an uppercase letter for its episode shortcut. 