### PR TITLE
include wipe effect into video capture

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -246,6 +246,10 @@ static void D_Wipe(void)
       I_UpdateNoBlit();
       M_Drawer();                   // menu is drawn even on top of wipes
       I_FinishUpdate();             // page flip or blit buffer
+      if (capturing_video && !doSkip)
+      {
+        I_CaptureFrame();
+      }
     }
   while (!done);
 }

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -246,7 +246,7 @@ static void D_Wipe(void)
       I_UpdateNoBlit();
       M_Drawer();                   // menu is drawn even on top of wipes
       I_FinishUpdate();             // page flip or blit buffer
-      if (capturing_video && !doSkip)
+      if (capturing_video && !doSkip && cap_wipescreen)
       {
         I_CaptureFrame();
       }

--- a/prboom2/src/i_capture.c
+++ b/prboom2/src/i_capture.c
@@ -73,6 +73,7 @@ const char *cap_tempfile2;
 int cap_remove_tempfiles;
 int cap_fps;
 int cap_frac;
+int cap_wipescreen;
 
 // parses a command with simple printf-style replacements.
 

--- a/prboom2/src/i_capture.h
+++ b/prboom2/src/i_capture.h
@@ -44,6 +44,7 @@ extern const char *cap_tempfile2;
 extern int cap_remove_tempfiles;
 extern int cap_fps;
 extern int cap_frac;
+extern int cap_wipescreen;
 
 // true if we're capturing video
 extern int capturing_video;

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1067,6 +1067,7 @@ default_t defaults[] =
   {"cap_tempfile2",{NULL, &cap_tempfile2},{0,"temp_v.nut"},UL,UL,def_str,ss_none},
   {"cap_remove_tempfiles", {&cap_remove_tempfiles},{1},0,1,def_bool,ss_none},
   {"cap_fps", {&cap_fps},{60},16,300,def_int,ss_none},
+  {"cap_wipescreen", {&cap_wipescreen},{0},0,1,def_bool,ss_none},
 
   {"Prboom-plus video settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"sdl_video_window_pos", {NULL,&sdl_video_window_pos}, {0,"center"},UL,UL,


### PR DESCRIPTION
fixes #503 and #207
draft while people are testing this

# Context

Video dumping code used to exclude the wipe effect, so those trying to have it in the video had to use kkapture or similar tools, which had problems with consistency.

https://github.com/coelckers/prboom-plus/blob/cf609b3b5b80b1fb72150db538ab1a70233107b4/prboom2/src/d_main.c#L493

Adding `I_CaptureFrame();` to the wipe code is probably enough, I just noticed that wipe effect takes 90 frames no matter what, and framerate of the resulting video is twice the `cap_fps`. So setting `cap_fps` to 35 gives what looks like regular DOS video: 70fps with every other frame being a duplicate.

I have no idea how to make the wipe effect respect its original real-time duration and account for the framerate.

https://github.com/coelckers/prboom-plus/blob/cf609b3b5b80b1fb72150db538ab1a70233107b4/prboom2/src/d_main.c#L245

How exactly `done` is determined and what determines `tics` is way above my head.

So if someone who understands the code can help me out here it'd be awesome. If not, this can already be used to get decent video.

ping @andrey-budko I guess?