### PR TITLE
allow not to quit on demo end

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -4288,14 +4288,15 @@ dboolean G_CheckDemoStatus (void)
 
       M_SaveDefaults();
 
-      I_Error ("Timed %u gametics in %u realtics = %-.1f frames per second",
-               (unsigned) gametic,realtics,
-               (unsigned) gametic * (double) TICRATE / realtics);
+      if (demo_endquit)
+        I_Error ("Timed %u gametics in %u realtics = %-.1f frames per second",
+                (unsigned) gametic,realtics,
+                (unsigned) gametic * (double) TICRATE / realtics);
     }
 
   if (demoplayback)
     {
-      if (singledemo)
+      if (singledemo && demo_endquit)
         I_SafeExit(0);  // killough
 
       if (demolumpnum != -1) {

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -329,6 +329,8 @@ default_t defaults[] =
    def_bool,ss_stat},
   {"demo_smoothturnsfactor", {&demo_smoothturnsfactor},  {6},1,SMOOTH_PLAYING_MAXFACTOR,
    def_int,ss_stat},
+  {"demo_endquit", {&demo_endquit},  {1},0,1,
+   def_bool,ss_stat},
   {"boom_autoswitch", {(int*)&boom_autoswitch}, {1}, 0, 1, def_bool, ss_none},
    
   {"Files",{NULL},{0},UL,UL,def_none,ss_none},

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -237,6 +237,8 @@ const char *demo_patterns_mask;
 char **demo_patterns_list;
 const char *demo_patterns_list_def[9];
 
+int demo_endquit;
+
 // demo ex
 int demo_extendedformat = -1;
 int demo_extendedformat_default;

--- a/prboom2/src/r_demo.h
+++ b/prboom2/src/r_demo.h
@@ -80,6 +80,8 @@ typedef struct
   char *missed;
 } patterndata_t;
 
+extern int demo_endquit;
+
 extern int demo_extendedformat;
 extern int demo_extendedformat_default;
 extern const char *demo_demoex_filename;


### PR DESCRIPTION
Incredibly useful if you don't want your video to end right when the demo ends.

For doom demos submitted to tasvideos we have to manually extend the demo by some unknown in advance duration in a hex editor so the entire ending could be encoded. Having a switch (ON by default, so old behavior remains) allows the encoder to end the video when they feel like it without pressure.