### PR TITLE
Remove shift when initializing translation tables vs. colormap.

### DIFF
--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -728,9 +728,9 @@ void R_InitTranslationTables (void)
     if (i >= 0x70 && i<= 0x7f)
       {
   // CPhipps - configurable player colours
-        translationtables[i] = colormaps[0][((i&0xf)<<9) + transtocolour[0]];
-        translationtables[i+256] = colormaps[0][((i&0xf)<<9) + transtocolour[1]];
-        translationtables[i+512] = colormaps[0][((i&0xf)<<9) + transtocolour[2]];
+        translationtables[i] = colormaps[0][(i&0xf) + transtocolour[0]];
+        translationtables[i+256] = colormaps[0][(i&0xf) + transtocolour[1]];
+        translationtables[i+512] = colormaps[0][(i&0xf) + transtocolour[2]];
       }
     else  // Keep all other colors as is.
       translationtables[i]=translationtables[i+256]=translationtables[i+512]=i;


### PR DESCRIPTION
As noted in [this post](https://www.doomworld.com/forum/post/2513485), PrBoom+ initializes its color translation tables against a darkened portion of the colormap rather than against the raw base palette. This causes a mismatch between PrBoom+ and other ports' behavior and, arguably, against the reference implementation.

This PR suggests removing the shift to a darker region of the colormap and would bring the translation in line with established norms.

Comment is invited; in particular if anyone has insight into why a darkened portion of the colormap was used.