### PR TITLE
Fix PortMidi level transitions

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -219,7 +219,7 @@ static void pm_shutdown (void)
 
 
 
-static PmEvent event_buffer[6 * 16];
+static PmEvent event_buffer[14 * 16];
 
 static const void *pm_registersong (const void *data, unsigned len)
 {
@@ -262,10 +262,22 @@ static const void *pm_registersong (const void *data, unsigned len)
     // end of RPN sequence
     event[4].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x64, 0x7f);
     event[5].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x65, 0x7f);
-    event += 6;
+    // all notes off
+    event[6].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x7b, 0x00);
+    // reset all controllers
+    event[7].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x79, 0x00);
+    // reset pan to 64 (center)
+    event[8].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x0a, 0x40);
+    // reset reverb to 40 and other effect controllers to 0
+    event[9].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5b, 0x28); // reverb
+    event[10].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5c, 0x00); // tremolo
+    event[11].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5d, 0x00); // chorus
+    event[12].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5e, 0x00); // detune
+    event[13].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5f, 0x00); // phaser
+    event += 14;
   }
 
-  Pm_Write(pm_stream, event_buffer, 6 * 16);
+  Pm_Write(pm_stream, event_buffer, 14 * 16);
 
   // handle not used
   return data;


### PR DESCRIPTION
**Bug:**
When a music track changes to a new one, old midi settings carry over if the new track doesn't redefine them. This causes problems with tracks that assume default settings are being used. This was partially addressed in [#101](https://github.com/coelckers/prboom-plus/issues/101) but for pitch bend range only.

**How to recreate:**
Download [Sunlust](https://www.doomworld.com/forum/topic/68089-sunlust-on-idgames/). Launch the game with `prboom-plus.exe -file sunlust.wad -warp 1` and listen to the music. Now launch the game with `prboom-plus.exe -file sunlust.wad`, start a new game manually, and listen again. The celesta (ch. 1 and 2) echoes badly and the slap bass (ch. 5) is positioned far to the right. Both have too much reverb. This is due to the pan, delay (detune), and reverb values carrying over from the title screen music.

**Fix:**
Set the above controllers, along with chorus and other effects, to their default values during a music change. The default values are from the [official midi specifications](https://www.midi.org/specifications).