### PR TITLE
Fix color translation tables to not rely on player map arrow colors.

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -85,7 +85,7 @@ int mapcolor_frnd;    // friendly sprite color
 int mapcolor_enemy;   // enemy sprite color
 int mapcolor_hair;    // crosshair color
 int mapcolor_sngl;    // single player arrow color
-int mapcolor_plyr[4] = { 112, 88, 64, 32 }; // colors for player arrows in multiplayer
+int mapcolor_plyr[4] = { 112, 96, 64, 176 }; // colors for player arrows in multiplayer
 
 //jff 3/9/98 add option to not show secret sectors until entered
 int map_secret_after;

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -704,6 +704,7 @@ void R_InitTranslationTables (void)
   int i, j;
 #define MAXTRANS 3
   byte transtocolour[MAXTRANS];
+  byte player_colors[] = {0x70, 0x60, 0x40, 0x20};
 
   // killough 5/2/98:
   // Remove dependency of colormaps aligned on 256-byte boundary
@@ -714,7 +715,7 @@ void R_InitTranslationTables (void)
   for (i=0; i<MAXTRANS; i++) transtocolour[i] = 255;
 
   for (i=0; i<MAXPLAYERS; i++) {
-    byte wantcolour = mapcolor_plyr[i];
+    byte wantcolour = player_colors[i];
     playernumtotrans[i] = 0;
     if (wantcolour != 0x70) // Not green, would like translation
       for (j=0; j<MAXTRANS; j++)


### PR DESCRIPTION
A suggested fix for https://github.com/kraflab/dsda-doom/issues/130 which does not use the player's map arrow colors as a basis for color translations (which seems like an odd choice to me).

This would bring the behavior of PrBoom+ for color translation in line with other ports.

Comment is invited.