### PR TITLE
Add configurable reverb and chorus for PortMidi

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -162,7 +162,7 @@ static void init_reset_buffer (void)
     // reset expression to 127 (max)
     event[5].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x0b, 0x7f);
     // reset pitch bend to 64 (center)
-    event[6].message = Pm_Message(MIDI_EVENT_PITCH_BEND | i, 0x40, 0x00);
+    event[6].message = Pm_Message(MIDI_EVENT_PITCH_BEND | i, 0x00, 0x40);
     // RPN sequence to adjust pitch bend range (RPN value 0x0000)
     event[7].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x65, 0x00);
     event[8].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x64, 0x00);

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -125,6 +125,8 @@ static unsigned char gm_system_on[] = {0xf0, 0x7e, 0x7f, 0x09, 0x01, 0xf7};
 static unsigned char gm2_system_on[] = {0xf0, 0x7e, 0x7f, 0x09, 0x03, 0xf7};
 static unsigned char xg_system_on[] = {0xf0, 0x43, 0x10, 0x4c, 0x00, 0x00, 0x7e, 0x00, 0xf7};
 static PmEvent event_buffer[13 * 16];
+static PmEvent event_buffer_reverb[16];
+static PmEvent event_buffer_chorus[16];
 
 static void reset_device (unsigned long when)
 {
@@ -139,6 +141,12 @@ static void reset_device (unsigned long when)
 
   // additional resets for compatibility with MS GS Wavetable Synth
   Pm_Write(pm_stream, event_buffer, 13 * 16);
+
+  // reverb and chorus send levels
+  if (mus_portmidi_reverb_level != 40)
+    Pm_Write(pm_stream, event_buffer_reverb, 16);
+  if (mus_portmidi_chorus_level != 0)
+    Pm_Write(pm_stream, event_buffer_chorus, 16);
 
   use_reset_delay = mus_portmidi_reset_delay > 0;
 }
@@ -173,6 +181,18 @@ static void init_reset_buffer (void)
     event[11].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x64, 0x7f);
     event[12].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x65, 0x7f);
     event += 13;
+  }
+
+  if (mus_portmidi_reverb_level != 40)
+  {
+    for (i = 0; i < 16; ++i)
+      event_buffer_reverb[i].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5b, mus_portmidi_reverb_level);
+  }
+
+  if (mus_portmidi_chorus_level != 0)
+  {
+    for (i = 0; i < 16; ++i)
+      event_buffer_chorus[i].message = Pm_Message(MIDI_EVENT_CONTROLLER | i, 0x5d, mus_portmidi_chorus_level);
   }
 }
 

--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -1356,6 +1356,8 @@ int mus_opl_gain; // NSM  fine tune OPL output level
 const char *mus_portmidi_reset_type; // portmidi reset type
 int mus_portmidi_reset_delay; // portmidi delay after reset
 int mus_portmidi_filter_sysex; // portmidi block sysex from midi files
+int mus_portmidi_reverb_level; // portmidi reverb send level
+int mus_portmidi_chorus_level; // portmidi chorus send level
 
 
 static void Exp_ShutdownMusic(void)

--- a/prboom2/src/i_sound.h
+++ b/prboom2/src/i_sound.h
@@ -142,6 +142,8 @@ extern int mus_opl_gain; // NSM  fine tune OPL output level
 extern const char *mus_portmidi_reset_type; // portmidi reset type
 extern int mus_portmidi_reset_delay; // portmidi delay after reset
 extern int mus_portmidi_filter_sysex; // portmidi block sysex from midi files
+extern int mus_portmidi_reverb_level; // portmidi reverb send level
+extern int mus_portmidi_chorus_level; // portmidi chorus send level
 
 // prefered MIDI player
 typedef enum

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -466,6 +466,8 @@ default_t defaults[] =
   {"mus_portmidi_reset_type",{NULL, &mus_portmidi_reset_type},{0,"gs"},UL,UL,def_str,ss_none}, // portmidi reset type (gs, gm, gm2, xg)
   {"mus_portmidi_reset_delay",{&mus_portmidi_reset_delay},{0},0,2000,def_int,ss_none}, // portmidi delay after reset (milliseconds)
   {"mus_portmidi_filter_sysex",{&mus_portmidi_filter_sysex},{0},0,1,def_bool,ss_none}, // portmidi block sysex from midi files
+  {"mus_portmidi_reverb_level",{&mus_portmidi_reverb_level},{40},0,127,def_int,ss_none}, // portmidi reverb send level
+  {"mus_portmidi_chorus_level",{&mus_portmidi_chorus_level},{0},0,127,def_int,ss_none}, // portmidi chorus send level
 
   {"Video settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"videomode",{NULL, &default_videomode},{0,"8bit"},UL,UL,def_str,ss_none},


### PR DESCRIPTION
This PR adds the ability to configure two commonly adjusted settings: reverb and chorus. These values will work with any MIDI file that doesn't already set reverb or chorus, such as the original Doom 1 and 2 music. Otherwise, the MIDI file settings have priority.

The motivation behind this addition is that a reset sets the reverb to 40 and chorus to 0, per MIDI specifications. However, some users may prefer control over these values if they were used to a different setting before (see: https://github.com/fabiangreffrath/crispy-doom/issues/940).

New settings in prboom-plus.cfg:

`mus_portmidi_reverb_level 40` (0 to 127)
`mus_portmidi_chorus_level 0` (0 to 127)