### PR TITLE
Adjust music volume slider to match vanilla Doom

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -358,7 +358,9 @@ static int mastervol;
 
 static void set_mastervol (unsigned long when)
 {
-  int vol = mastervol * pm_volume / 15;
+  int vol = mastervol * pm_volume * 8 / 100;
+  if (vol > 16383)
+    vol = 16383;
   unsigned char data[] = {0xf0, 0x7f, 0x7f, 0x04, 0x01, vol & 0x7f, vol >> 7, 0xf7};
   Pm_WriteSysEx(pm_stream, when, data);
 }

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -1350,7 +1350,9 @@ void I_midiOutSetVolumes(int volume)
     volume = 15;
   if (volume < 0)
     volume = 0;
-  calcVolume = (65535 * volume / 15);
+  calcVolume = 65535 * volume * 8 / 100;
+  if (calcVolume > 65535)
+    calcVolume = 65535;
 
   //SDL_LockAudio(); // this function doesn't touch anything the audio callback touches
 


### PR DESCRIPTION
This is similar to https://github.com/chocolate-doom/chocolate-doom/pull/1508 but adjustments are made to the master volume instead of individual channels to achieve a similar effect.
