### PR TITLE
Use non-linear scaling for high volume levels

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -120,9 +120,9 @@ static const char *pm_name (void)
 
 // converts master volume from linear scaling to non-linear scaling that
 // closely follows vanilla doom behavior but with a smooth transition when
-// approaching maximum volume. cast value to float and divide by 1000.
-const int volume_correction[] = {1000, 1200, 1200, 1200, 1200, 1200, 1200, 1200,
-                                 1200, 1200, 1200, 1181, 1152, 1108, 1055, 1000};
+// approaching maximum volume
+const float volume_correction[] = {1.000, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200,
+                                   1.200, 1.200, 1.200, 1.181, 1.152, 1.108, 1.055, 1.000};
 
 static dboolean use_reset_delay;
 static unsigned char gs_reset[] = {0xf0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7f, 0x00, 0x41, 0xf7};
@@ -363,7 +363,7 @@ static int mastervol;
 
 static void set_mastervol (unsigned long when)
 {
-  int vol = (float)volume_correction[pm_volume] / 1000 * mastervol * pm_volume / 15;
+  int vol = volume_correction[pm_volume] * mastervol * pm_volume / 15;
   unsigned char data[] = {0xf0, 0x7f, 0x7f, 0x04, 0x01, vol & 0x7f, vol >> 7, 0xf7};
   Pm_WriteSysEx(pm_stream, when, data);
 }

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -118,6 +118,11 @@ static const char *pm_name (void)
 #include <delayimp.h>
 #endif
 
+// converts master volume from linear scaling to non-linear scaling that
+// closely follows vanilla doom behavior but with a smooth transition when
+// approaching maximum volume. cast value to float and divide by 1000.
+const int volume_correction[] = {1000, 1200, 1200, 1200, 1200, 1200, 1200, 1200,
+                                 1200, 1200, 1200, 1181, 1152, 1108, 1055, 1000};
 
 static dboolean use_reset_delay;
 static unsigned char gs_reset[] = {0xf0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7f, 0x00, 0x41, 0xf7};
@@ -358,9 +363,7 @@ static int mastervol;
 
 static void set_mastervol (unsigned long when)
 {
-  int vol = mastervol * pm_volume * 8 / 100;
-  if (vol > 16383)
-    vol = 16383;
+  int vol = (float)volume_correction[pm_volume] / 1000 * mastervol * pm_volume / 15;
   unsigned char data[] = {0xf0, 0x7f, 0x7f, 0x04, 0x01, vol & 0x7f, vol >> 7, 0xf7};
   Pm_WriteSysEx(pm_stream, when, data);
 }

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -1350,7 +1350,7 @@ void I_midiOutSetVolumes(int volume)
     volume = 15;
   if (volume < 0)
     volume = 0;
-  calcVolume = (float)volume_correction[volume] / 1000 * 65535 * volume / 15;
+  calcVolume = volume_correction[volume] * 65535 * volume / 15;
 
   //SDL_LockAudio(); // this function doesn't touch anything the audio callback touches
 

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -1350,9 +1350,7 @@ void I_midiOutSetVolumes(int volume)
     volume = 15;
   if (volume < 0)
     volume = 0;
-  calcVolume = 65535 * volume * 8 / 100;
-  if (calcVolume > 65535)
-    calcVolume = 65535;
+  calcVolume = (float)volume_correction[volume] / 1000 * 65535 * volume / 15;
 
   //SDL_LockAudio(); // this function doesn't touch anything the audio callback touches
 

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -357,7 +357,7 @@ int I_MessageBox(const char* text, unsigned int type);
 dboolean SmoothEdges(unsigned char * buffer,int w, int h);
 
 #ifdef _WIN32
-extern const int volume_correction[];
+extern const float volume_correction[];
 extern int mus_extend_volume;
 void I_midiOutSetVolumes(int volume);
 #endif

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -357,6 +357,7 @@ int I_MessageBox(const char* text, unsigned int type);
 dboolean SmoothEdges(unsigned char * buffer,int w, int h);
 
 #ifdef _WIN32
+extern const int volume_correction[];
 extern int mus_extend_volume;
 void I_midiOutSetVolumes(int volume);
 #endif


### PR DESCRIPTION
As discussed in https://github.com/coelckers/prboom-plus/pull/531, there is a good argument in favor of the music volume slider behaving like vanilla Doom but modified to smoothly transition when approaching maximum volume. This is so the user can perceive differences between higher volume slider settings which was a shortcoming of vanilla Doom. Source ports that prefer staying faithful to vanilla Doom should continue using the vanilla Doom approach. Other than that, both solutions are pretty similar.

Here's a plot I made from the previous PR. PrBoom+ targets the yellow line now:

![chart](https://user-images.githubusercontent.com/56656010/190838898-d23cc2de-f59e-41a4-9f3b-9267e7586af0.png)

Here's a capture of the MIDI output as the music volume slider is adjusted from 0 to 15:

```
F0 7F 7F 04 01 00 00 F7    0
F0 7F 7F 04 01 1E 0A F7    1310
F0 7F 7F 04 01 3D 14 F7    2621
F0 7F 7F 04 01 5B 1E F7    3931
F0 7F 7F 04 01 7A 28 F7    5242
F0 7F 7F 04 01 19 33 F7    6553
F0 7F 7F 04 01 37 3D F7    7863
F0 7F 7F 04 01 56 47 F7    9174
F0 7F 7F 04 01 75 51 F7    10485
F0 7F 7F 04 01 13 5C F7    11795
F0 7F 7F 04 01 32 66 F7    13106
F0 7F 7F 04 01 6C 6E F7    14188
F0 7F 7F 04 01 7A 75 F7    15098
F0 7F 7F 04 01 74 7A F7    15732
F0 7F 7F 04 01 03 7E F7    16131
F0 7F 7F 04 01 7F 7F F7    16383
```

So all SysEx messages are correct. As before, if a MIDI file tries to change the master volume, the message will be intercepted and scaled appropriately to the current volume slider and now with a correction factor applied as well.

I'll leave this as a draft so others can provide feedback.