### PR TITLE
Adjust PortMidi volume slider to match midiOutSetVolume

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -76,6 +76,7 @@ const music_player_t pm_player =
 #include "lprintf.h"
 #include "midifile.h"
 #include "i_sound.h" // for snd_mididev
+#include <math.h>
 
 static midi_event_t **events;
 static int eventpos;
@@ -118,11 +119,6 @@ static const char *pm_name (void)
 #include <delayimp.h>
 #endif
 
-// converts master volume from linear scaling to non-linear scaling that
-// closely follows vanilla doom behavior but with a smooth transition when
-// approaching maximum volume
-const float volume_correction[] = {1.000, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200,
-                                   1.200, 1.200, 1.200, 1.181, 1.152, 1.108, 1.055, 1.000};
 
 static dboolean use_reset_delay;
 static unsigned char gs_reset[] = {0xf0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7f, 0x00, 0x41, 0xf7};
@@ -363,7 +359,7 @@ static int mastervol;
 
 static void set_mastervol (unsigned long when)
 {
-  int vol = volume_correction[pm_volume] * mastervol * pm_volume / 15;
+  int vol = mastervol * sqrt((float)pm_volume / 15);
   unsigned char data[] = {0xf0, 0x7f, 0x7f, 0x04, 0x01, vol & 0x7f, vol >> 7, 0xf7};
   Pm_WriteSysEx(pm_stream, when, data);
 }

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -1350,7 +1350,7 @@ void I_midiOutSetVolumes(int volume)
     volume = 15;
   if (volume < 0)
     volume = 0;
-  calcVolume = volume_correction[volume] * 65535 * volume / 15;
+  calcVolume = (65535 * volume / 15);
 
   //SDL_LockAudio(); // this function doesn't touch anything the audio callback touches
 

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -357,7 +357,6 @@ int I_MessageBox(const char* text, unsigned int type);
 dboolean SmoothEdges(unsigned char * buffer,int w, int h);
 
 #ifdef _WIN32
-extern const float volume_correction[];
 extern int mus_extend_volume;
 void I_midiOutSetVolumes(int volume);
 #endif


### PR DESCRIPTION
This PR removes the changes of #531 and #532.

Starting from that baseline, music volume is initially scaled linearly:
```
master_volume_out = slider_value / 15 * master_volume_in
```
This is updated to be equivalent to SDL_mixer which uses WinMM `midiOutSetVolume()` which scales the volume non-linearly: 
```
master_volume_out = sqrt(slider_value / 15) * master_volume_in
```
Here's a plot showing gain vs. slider position for a note that's playing at full volume:

![volume-changes](https://user-images.githubusercontent.com/56656010/191878037-9f2f1f60-67c2-4b0e-8236-1d3e1c610a5e.png)
(0 dB means no drop in volume, most people won't hear anything by -40 dB, and -60 dB is silent)

Instead of targeting vanilla Doom's [completely broken](https://github.com/chocolate-doom/chocolate-doom/pull/1508#issuecomment-1250443255) music slider, master volume now emulates SDL_mixer but without using `midiOutSetVolume()` which is incompatible with newer versions of Windows.

This update still has the benefits of the previous two PRs. The music slider has a slightly wider usable range, especially in the lower half, and the upper half continues to have perceptible changes when approaching max volume. Users will perceive the volume to be slightly higher across most of the slider range, but the max volume is the same as before.

Thanks to the previous reviewers for asking the right questions that led to this solution.