### PR TITLE
Remove alpha channel from FBO scene texture.

### DIFF
--- a/prboom2/src/gl_fbo.c
+++ b/prboom2/src/gl_fbo.c
@@ -117,7 +117,7 @@ static dboolean gld_CreateScreenSizeFBO(void)
   
   glGenTextures(1, &glSceneImageTextureFBOTexID);
   glBindTexture(GL_TEXTURE_2D, glSceneImageTextureFBOTexID);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, SCREENWIDTH, SCREENHEIGHT, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, SCREENWIDTH, SCREENHEIGHT, 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);


### PR DESCRIPTION
This PR would remove the alpha channel from the scene FBO texture. This is the same fix applied [to dsda-doom here](https://github.com/kraflab/dsda-doom/issues/139). Note that the issue in that thread is a problem with the source WAD, but since most renderers will blank out this type of error I think it's fine.

This PR would fix the combination of motion blur and shadows, which otherwise don't work together properly. This fix would hardly be noticeable in PrBoom+, but it is still a bug so I think we should fix it.