### PR TITLE
Fixing wall texture bleed when a sector is inside the sky

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1614,6 +1614,7 @@ void gld_AddWall(seg_t *seg)
   float lineheight, linelength;
   int rellight = 0;
   int backseg;
+  dboolean fix_sky_bleed = false;
 
   int side = (seg->sidedef == &sides[seg->linedef->sidenum[0]] ? 0 : 1);
   if (linerendered[side][seg->linedef->iLineID] == rendermarker)
@@ -1752,6 +1753,10 @@ void gld_AddWall(seg_t *seg)
           toptexture == NO_TEXTURE && midtexture == NO_TEXTURE)
         {
           wall.ybottom=(float)min_ceiling/MAP_SCALE;
+          if (bs->ceilingheight < fs->floorheight)
+          {
+              fix_sky_bleed = true;
+          }
           gld_AddSkyTexture(&wall, frontsector->sky, backsector->sky, SKY_CEILING);
         }
         else
@@ -1760,7 +1765,15 @@ void gld_AddWall(seg_t *seg)
             backsector->ceilingpic != skyflatnum ||
             backsector->ceilingheight <= frontsector->floorheight)
           {
-            wall.ybottom=(float)max_ceiling/MAP_SCALE;
+            if (frontsector->ceilingpic == skyflatnum && frontsector->ceilingheight < backsector->floorheight)
+            {
+                wall.ybottom=(float)min_ceiling/MAP_SCALE;
+                fix_sky_bleed = true;
+            }
+            else
+            {
+                wall.ybottom=(float)max_ceiling/MAP_SCALE;
+            }
             gld_AddSkyTexture(&wall, frontsector->sky, backsector->sky, SKY_CEILING);
           }
         }
@@ -1964,6 +1977,12 @@ bottomtexture:
       if (temptex)
       {
         wall.gltexture=temptex;
+        fixed_t rowoffset = seg->sidedef->rowoffset;
+        if (fix_sky_bleed)
+        {
+            ceiling_height = MIN(frontsector->ceilingheight, backsector->ceilingheight);
+            seg->sidedef->rowoffset += (MAX(frontsector->floorheight, backsector->floorheight) - min_ceiling);
+        }
         CALC_Y_VALUES(wall, lineheight, floor_height, ceiling_height);
         CALC_TEX_VALUES_BOTTOM(
           wall, seg, backseg, (LINE->flags & ML_DONTPEGBOTTOM)>0,
@@ -1971,6 +1990,7 @@ bottomtexture:
           floor_height-frontsector->ceilingheight
         );
         gld_AddDrawWallItem(GLDIT_WALL, &wall);
+        seg->sidedef->rowoffset = rowoffset;
       }
     }
   }


### PR DESCRIPTION
This is an initial attempt at solving #540. It needs some testing as GL sky rendering is notoriously tricky.

To explain what's going on:

The sky in the GL renderer is more like "the space where stuff _isn't_".
When you move a texture into the sky, the software renderer will clip it at the ceiling intersection. The GL renderer doesn't know about this and will let the texture stretch into the sky.

To fix this, this patch detects the condition and does a few things:
1. Manually clip the wall top at the sky ceiling intersection point (i.e., what the software renderer does)
2. Insert an invisible blocking wall to prevent stuff behind from drawing
3. Adjust the texture offset to compensate for the "chopped" texture

Perhaps you wonder why (2) is not enough: this is because 2 alone will cause z-fighting as both the sky wall and the drawn texture will compete for the same z coordinate. I could nudge the sky wall in the z-buffer but this seems questionable to me and may cause little bleed-overs to happen.

Comment as always is invited. There could be cleaner ways to do this if anyone thinks of one.