### PR TITLE
Fix MIDI looping when using reset delay

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -553,32 +553,28 @@ static void pm_render (void *vdest, unsigned bufflen)
   {
     double eventdelta;
     currevent = events[eventpos];
-    
-    if (use_reset_delay)
-    {
-      // delay after reset, for real devices only (e.g. roland sc-55)
-      currevent->delta_time += mus_portmidi_reset_delay / spmc;
-      use_reset_delay = false;
-    }
 
     // how many samples away event is
     eventdelta = currevent->delta_time * spmc;
 
+    if (use_reset_delay)
+    {
+      // delay after reset, for real devices only (e.g. roland sc-55)
+      eventdelta += mus_portmidi_reset_delay;
+    }
 
     // how many we will render (rounding down); include delta offset
     samples = (unsigned) (eventdelta + pm_delta);
-
 
     if (samples + sampleswritten > length)
     { // overshoot; render some samples without processing an event
       break;
     }
 
-
+    use_reset_delay = false;
     sampleswritten += samples;
     pm_delta -= samples;
- 
-    
+
     // process event
     when = trackstart + sampleswritten;
     switch (currevent->event_type)


### PR DESCRIPTION
This only applies to users who enable `mus_portmidi_reset_delay` for hardware MIDI devices.
1. If the song contains a reset message, the reset delay will no longer increase every song loop.
2. If the song doesn't contain a reset message, the reset delay will only occur on first play and not every song loop.