### PR TITLE
Fix FluidSynth mode and polyphony

### DIFF
--- a/prboom2/src/MUSIC/flplayer.c
+++ b/prboom2/src/MUSIC/flplayer.c
@@ -166,9 +166,9 @@ static int fl_init (int samplerate)
   // gain control
   FSET (num, "synth.gain", mus_fluidsynth_gain / 100.0); // 0.0 - 0.2 - 10.0
   // behavior wrt bank select messages
-  FSET (str, "synth.midi-bank-select", "gm"); // general midi mode
-  // general midi spec says no more than 24 voices needed
-  FSET (int, "synth.polyphony", 24);
+  FSET (str, "synth.midi-bank-select", "gs"); // fluidsynth default
+  // general midi spec says 24 voices, but modern midi songs use more
+  FSET (int, "synth.polyphony", 256); // fluidsynth default
 
   // we're not using the builtin shell or builtin midiplayer,
   // and our own access to the synth is protected by mutex in i_sound.c


### PR DESCRIPTION
This PR sets midi-bank-select and polyphony values to their defaults: gs and 256, respectively.

PrBoom+ used to have typos that meant default values were used for midi-bank-select and polyphony and that was fine. https://github.com/coelckers/prboom-plus/commit/495fd599b11283617bbc6ef966e7dbd709fc61c5 fixed the typos, so PrBoom+ started using poorly chosen values that cause notes to drop or cut out and disables GS features if a MIDI file uses them.

Download this: [polyphony.zip](https://github.com/coelckers/prboom-plus/files/10149759/polyphony.zip)
```
prboom-plus.exe -iwad doom2.wad -file polyphony.wad -warp 1
```
Listen to the trombone that plays in the left channel. If it cuts out, the polyphony is set too low.

References:
- [Doomworld post](https://www.doomworld.com/forum/topic/106866-prboom-262-feb-11-2022/?page=55&tab=comments#comment-2578953)
- [midi-bank-select](https://www.fluidsynth.org/api/settings_synth.html#settings_synth_midi-bank-select)
- [polyphony](https://www.fluidsynth.org/api/settings_synth.html#settings_synth_polyphony)