### PR TITLE
Disable sector special 17 in v1.2 compat

### DIFF
--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2667,7 +2667,9 @@ void P_SpawnSpecials (void)
 
       case 17:
         // fire flickering
-        P_SpawnFireFlicker(sector);
+        // first introduced in official v1.4 beta
+        if (compatibility_level > doom_12_compatibility)
+          P_SpawnFireFlicker(sector);
         break;
     }
   }


### PR DESCRIPTION
The first vanilla exec to support sector special 17 (random flicker) was the official v1.4 beta. Disabling it for v1.2 compat solves the desync on DEMO1 of CHURCH.WAD.