### PR TITLE
Supply correct texture format for GL wipe.

### DIFF
--- a/prboom2/src/gl_wipe.c
+++ b/prboom2/src/gl_wipe.c
@@ -60,7 +60,7 @@ GLuint CaptureScreenAsTexID(void)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-  glTexImage2D(GL_TEXTURE_2D, 0, 3, 
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 
     gld_GetTexDimension(SCREENWIDTH), gld_GetTexDimension(SCREENHEIGHT), 
     0, GL_RGB, GL_UNSIGNED_BYTE, 0);
 


### PR DESCRIPTION
Originally reported here: https://github.com/kraflab/dsda-doom/issues/220#issue-1598749918

The call to `glTexImage2D` in `gl_wipe.c` used an incorrect internal image format. This should fix it.