### PR TITLE
PortMidi: Update volume after "reset all controllers" event

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -613,7 +613,7 @@ static void pm_render (void *vdest, unsigned bufflen)
               {
                 writeevent (when, 0xB0, i, 0x7B, 0x00); // all notes off
                 writeevent (when, 0xB0, i, 0x79, 0x00); // reset all controllers
-                write_volume (when, i, DEFAULT_VOLUME); // reset volume
+                write_volume (when, i, channel_volume[i]); // reapply volume
               }
               continue;
             }
@@ -629,8 +629,9 @@ static void pm_render (void *vdest, unsigned bufflen)
         }
         else if (currevent->data.channel.param1 == 0x79)
         {
-          writeevent (when, 0xB0, currevent->data.channel.channel, 0x79, 0x00); // reset all controllers
-          write_volume (when, currevent->data.channel.channel, DEFAULT_VOLUME); // reset volume
+          int i = currevent->data.channel.channel;
+          writeevent (when, 0xB0, i, 0x79, 0x00); // reset all controllers
+          write_volume (when, i, channel_volume[i]); // reapply volume
           break;
         }
         // fall through

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -613,6 +613,7 @@ static void pm_render (void *vdest, unsigned bufflen)
               {
                 writeevent (when, 0xB0, i, 0x7B, 0x00); // all notes off
                 writeevent (when, 0xB0, i, 0x79, 0x00); // reset all controllers
+                write_volume (when, i, DEFAULT_VOLUME); // reset volume
               }
               continue;
             }
@@ -624,6 +625,12 @@ static void pm_render (void *vdest, unsigned bufflen)
         if (currevent->data.channel.param1 == MIDI_CONTROLLER_MAIN_VOLUME)
         {
           write_volume (when, currevent->data.channel.channel, currevent->data.channel.param2);
+          break;
+        }
+        else if (currevent->data.channel.param1 == 0x79)
+        {
+          writeevent (when, 0xB0, currevent->data.channel.channel, 0x79, 0x00); // reset all controllers
+          write_volume (when, currevent->data.channel.channel, DEFAULT_VOLUME); // reset volume
           break;
         }
         // fall through


### PR DESCRIPTION
This is a workaround for a bug that appears when using PortMidi, Windows, and the default Windows MIDI synth (Microsoft GS Wavetable Synth). When the MS GS Synth receives a "reset all controllers" event it also resets the channel volume, deviating from MIDI spec. As a result, in certain cases the channel can be audible even if the music volume slider is set to zero. The workaround is to always update the volume after a "reset all controllers" event.

Test wad: [reset_all_ctrls_test.zip](https://github.com/coelckers/prboom-plus/files/11107003/reset_all_ctrls_test.zip)
