### PR TITLE
PortMidi: Optimize reset messages

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -136,14 +136,19 @@ static void reset_device (void)
 {
   Pm_Write(pm_stream, event_notes_off, 16);
   Pm_Write(pm_stream, event_sound_off, 16);
-  Pm_Write(pm_stream, event_reset, 16 * 6);
 
-  if (sysex_reset != NULL)
+  if (sysex_reset == NULL)
+    Pm_Write(pm_stream, event_reset, 16 * 6);
+  else
     Pm_WriteSysEx(pm_stream, 0, sysex_reset);
 
   Pm_Write(pm_stream, event_pbs, 16 * 6);
-  Pm_Write(pm_stream, event_reverb, 16);
-  Pm_Write(pm_stream, event_chorus, 16);
+
+  if (mus_portmidi_reverb_level > -1 || sysex_reset == NULL)
+    Pm_Write(pm_stream, event_reverb, 16);
+
+  if (mus_portmidi_chorus_level > -1 || sysex_reset == NULL)
+    Pm_Write(pm_stream, event_chorus, 16);
 
   use_reset_delay = mus_portmidi_reset_delay > 0;
 }
@@ -153,6 +158,9 @@ static void init_reset_buffer (void)
   int i;
   PmEvent *reset = event_reset;
   PmEvent *pbs = event_pbs;
+  int reverb = mus_portmidi_reverb_level;
+  int chorus = mus_portmidi_chorus_level;
+
   for (i = 0; i < 16; ++i)
   {
     event_notes_off[i].message = Pm_Message(0xB0 | i, 0x7B, 0x00);
@@ -173,9 +181,6 @@ static void init_reset_buffer (void)
     pbs[4].message = Pm_Message(0xB0 | i, 0x64, 0x7F); // null RPN LSB
     pbs[5].message = Pm_Message(0xB0 | i, 0x65, 0x7F); // null RPN MSB
     pbs += 6;
-
-    event_reverb[i].message = Pm_Message(0xB0 | i, 0x5B, mus_portmidi_reverb_level);
-    event_chorus[i].message = Pm_Message(0xB0 | i, 0x5D, mus_portmidi_chorus_level);
   }
 
   if (!strcasecmp(mus_portmidi_reset_type, "gs"))
@@ -188,6 +193,26 @@ static void init_reset_buffer (void)
     sysex_reset = xg_system_on;
   else
     sysex_reset = NULL;
+
+  // if no reverb specified and no SysEx reset selected, then use GM default
+  if (reverb == -1 && sysex_reset == NULL)
+    reverb = 40;
+
+  if (reverb > -1)
+  {
+    for (i = 0; i < 16; ++i)
+      event_reverb[i].message = Pm_Message(0xB0 | i, 0x5B, reverb);
+  }
+
+  // if no chorus specified and no SysEx reset selected, then use GM default
+  if (chorus == -1 && sysex_reset == NULL)
+    chorus = 0;
+
+  if (chorus > -1)
+  {
+    for (i = 0; i < 16; ++i)
+      event_chorus[i].message = Pm_Message(0xB0 | i, 0x5D, chorus);
+  }
 }
 
 static int pm_init (int samplerate)

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -460,8 +460,8 @@ default_t defaults[] =
   {"mus_portmidi_reset_type",{NULL, &mus_portmidi_reset_type},{0,"gm"},UL,UL,def_str,ss_none}, // portmidi reset type (none, gs, gm, gm2, xg)
   {"mus_portmidi_reset_delay",{&mus_portmidi_reset_delay},{0},0,2000,def_int,ss_none}, // portmidi delay after reset (milliseconds)
   {"mus_portmidi_filter_sysex",{&mus_portmidi_filter_sysex},{1},0,1,def_bool,ss_none}, // portmidi block sysex from midi files
-  {"mus_portmidi_reverb_level",{&mus_portmidi_reverb_level},{40},0,127,def_int,ss_none}, // portmidi reverb send level
-  {"mus_portmidi_chorus_level",{&mus_portmidi_chorus_level},{0},0,127,def_int,ss_none}, // portmidi chorus send level
+  {"mus_portmidi_reverb_level",{&mus_portmidi_reverb_level},{-1},-1,127,def_int,ss_none}, // portmidi reverb send level
+  {"mus_portmidi_chorus_level",{&mus_portmidi_chorus_level},{-1},-1,127,def_int,ss_none}, // portmidi chorus send level
 
   {"Video settings",{NULL},{0},UL,UL,def_none,ss_none},
   {"videomode",{NULL, &default_videomode},{0,"8bit"},UL,UL,def_str,ss_none},


### PR DESCRIPTION
This reduces the amount of messages sent during a reset, similar to Chocolate, Woof, etc. This also fixes a regression where wads with mid-level music changes were causing the game to pause briefly (https://github.com/coelckers/prboom-plus/files/7654830/MusChange.zip). Ideally, music should be handled on a separate thread, but this is a simple solution for now. 